### PR TITLE
Fix direct modex logic when local rank information is requested.

### DIFF
--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -123,6 +123,7 @@ pmix_status_t pmix_pending_request(pmix_nspace_t *nptr, int rank,
     pmix_rank_info_t *iptr;
     pmix_hash_table_t *ht;
     pmix_status_t rc;
+    bool is_local = false;
 
     /* 1. Try to satisfy the request right now */
 
@@ -132,6 +133,7 @@ pmix_status_t pmix_pending_request(pmix_nspace_t *nptr, int rank,
         if (iptr->rank == rank) {
             /* in case it is known local rank - check local table */
             ht = &nptr->server->mylocal;
+            is_local = true;
             break;
         }
     }
@@ -175,7 +177,7 @@ pmix_status_t pmix_pending_request(pmix_nspace_t *nptr, int rank,
         pmix_list_append(&pmix_server_globals.local_reqs, &lcd->super);
 
         /* check & send request if need/possible */
-        if (nptr->server->all_registered && NULL == info) {
+        if (nptr->server->all_registered && !is_local) {
             if (NULL != pmix_host_server.direct_modex) {
                 pmix_host_server.direct_modex(&lcd->proc, info, ninfo, dmdx_cbfunc, lcd);
             } else {


### PR DESCRIPTION
@rhc54 
This PR address the following problem seen in OMPI integration:
**Configuration**: 2 processes on the same node.
**Changes in OMPI**: changing the OPAL_MODEX macro in opal/mca/pmix/pmix.h to use the fence_nb call with a “0” for collect_data.
**What is supposed to happen** is that the PMIx server library sees that these are both local procs, and so it “holds” the request inside itself until the requested data arrives. Then it delivers the data to the requesting process.
**What is happening is** that the PMIx server library immediately fires a direct_modex request to the host. Somehow, the “lcd” portion of the request is getting trashed, and chaos ensues.
