### PR TITLE
Fix double-free error in pmix_server_commit.

### DIFF
--- a/src/buffer_ops/buffer_ops.h
+++ b/src/buffer_ops/buffer_ops.h
@@ -68,6 +68,8 @@ PMIX_DECLSPEC pmix_status_t pmix_value_unload(pmix_value_t *kv, void **data,
         (b)->bytes_allocated = (s);                     \
         (b)->pack_ptr = ((char*)(b)->base_ptr) + (s);   \
         (b)->unpack_ptr = (b)->base_ptr;                \
+        (d) = NULL;                                     \
+        (s) = 0;                                        \
     } while(0);
 
 #define PMIX_UNLOAD_BUFFER(b, d, s)             \

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -919,9 +919,6 @@ void pmix_client_process_nspace_blob(const char *nspace, pmix_buffer_t *bptr)
             bo = &(kptr->value->data.bo);
             PMIX_CONSTRUCT(&buf2, pmix_buffer_t);
             PMIX_LOAD_BUFFER(&buf2, bo->bytes, bo->size);
-            /* protect the data */
-            kptr->value->data.bo.bytes = NULL;
-            kptr->value->data.bo.size = 0;
             PMIX_RELEASE(kptr);
             /* start by unpacking the rank */
             cnt = 1;
@@ -958,9 +955,6 @@ void pmix_client_process_nspace_blob(const char *nspace, pmix_buffer_t *bptr)
             bo = &(kptr->value->data.bo);
             PMIX_CONSTRUCT(&buf2, pmix_buffer_t);
             PMIX_LOAD_BUFFER(&buf2, bo->bytes, bo->size);
-            /* protect the data */
-            kptr->value->data.bo.bytes = NULL;
-            kptr->value->data.bo.size = 0;
             PMIX_RELEASE(kptr);
             /* start by unpacking the number of nodes */
             cnt = 1;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -693,12 +693,10 @@ static void _execute_collective(int sd, short args, void *cbdata)
                     pmix_bfrop.pack(&rankbuf, &info->rank, 1, PMIX_INT);
                     PMIX_CONSTRUCT(&xfer, pmix_buffer_t);
                     PMIX_LOAD_BUFFER(&xfer, val->data.bo.bytes, val->data.bo.size);
+                    PMIX_VALUE_RELEASE(val);
                     pmix_buffer_t *pxfer = &xfer;
                     pmix_bfrop.pack(&rankbuf, &pxfer, 1, PMIX_BUFFER);
-                    xfer.base_ptr = NULL;
-                    xfer.bytes_used = 0;
                     PMIX_DESTRUCT(&xfer);
-                    PMIX_VALUE_RELEASE(val);
                     /* now pack this proc's contribution into the bucket */
                     pmix_buffer_t *pdatabuf = &rankbuf;
                     pmix_bfrop.pack(&databuf, &pdatabuf, 1, PMIX_BUFFER);

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -550,12 +550,10 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd,
                     pmix_bfrop.pack(&rankbuf, &rkinfo->rank, 1, PMIX_INT);
                     PMIX_CONSTRUCT(&xfer, pmix_buffer_t);
                     PMIX_LOAD_BUFFER(&xfer, val->data.bo.bytes, val->data.bo.size);
+                    PMIX_VALUE_RELEASE(val);
                     pmix_buffer_t *pxfer = &xfer;
                     pmix_bfrop.pack(&rankbuf, &pxfer, 1, PMIX_BUFFER);
-                    xfer.base_ptr = NULL;
-                    xfer.bytes_used = 0;
                     PMIX_DESTRUCT(&xfer);
-                    PMIX_VALUE_RELEASE(val);
                     /* now pack this proc's contribution into the bucket */
                     pmix_buffer_t *pdatabuf = &rankbuf;
                     pmix_bfrop.pack(&databuf, &pdatabuf, 1, PMIX_BUFFER);


### PR DESCRIPTION
This error was noticed when running with
```export OMPI_MCA_opal_pmix_base_async_modex=1```
In this case it is possible that dmdx requests will arrive before the data is available. This means that the following codepath was enabled:
https://github.com/pmix/releases/blob/v1.1/src/server/pmix_server_ops.c#L187:L213

The error occurs because data was free()'d twice, here:
https://github.com/pmix/releases/blob/v1.1/src/server/pmix_server_ops.c#L200
and here:
https://github.com/pmix/releases/blob/v1.1/src/server/pmix_server_ops.c#L207.
