### PR TITLE
Implemented error handler registration and notify fns and error handling bug fixes

### DIFF
--- a/include/pmix/pmix_common.h
+++ b/include/pmix/pmix_common.h
@@ -162,10 +162,26 @@ BEGIN_C_DECLS
 #define PMIX_PROC_BLOB             "pmix.pblob"        // (pmix_byte_object_t) packed blob of process data
 #define PMIX_MAP_BLOB              "pmix.mblob"        // (pmix_byte_object_t) packed blob of process location
 
+/* error handler registration  and notification info keys */
+#define PMIX_ERROR_NAME            "pmix.errname"           /* enum pmix_status_t specific error to be notified */
+#define PMIX_ERROR_GROUP_COMM      "pmix.errgroup.comm"     /* bool - set true to get comm  errors notification */
+#define PMIX_ERROR_GROUP_ABORT     "pmix.errgroup.abort"    /* bool -set true to get abort errors notification */
+#define PMIX_ERROR_GROUP_MIGRATE   "pmix.errgroup.migrate"  /* bool -set true to get migrate errors notification  */
+#define PMIX_ERROR_GROUP_RESOURCE  "pmix.errgroup.resource" /* bool -set true to get resource errors notification */
+#define PMIX_ERROR_GROUP_SPAWN     "pmix.errgroup.spawn"    /* bool - set true to get spawn errors notification */
+#define PMIX_ERROR_GROUP_NODE      "pmix.errgroup.node"     /* bool -set true to get node status errors */
+#define PMIX_ERROR_GROUP_LOCAL     "pmix.errgroup.local"    /* bool set true to get local errors */
+#define PMIX_ERROR_GROUP_GENERAL   "pmix.errgroup.gen"      /* bool set true to get notified af generic errors */
+
+/* error notification keys */
+#define PMIX_ERROR_SCOPE           "pmix.errscope"      /* int (enum pmix_scope_t) scope of error notification*/
+#define PMIX_ERROR_NODE_NAME       "pmix.errnode.name"   /* name of the node that is in error or which reported the error.*/
+#define PMIX_ERROR_SEVERITY        "pmix.errseverity"    /* the severity of the notified (reported) error */
+
 
 /****    PMIX ERROR CONSTANTS    ****/
 /* PMIx errors are always negative, with 0 reserved for success */
-#define PMIX_ERROR_MIN  -42  // set equal to number of non-zero entries in enum
+#define PMIX_ERROR_MIN  -49  // set equal to number of non-zero entries in enum
 
 typedef enum {
     PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER = PMIX_ERROR_MIN,
@@ -211,7 +227,13 @@ typedef enum {
     PMIX_ERR_HANDSHAKE_FAILED,
     PMIX_ERR_INVALID_CRED,
     PMIX_EXISTS,
-
+    PMIX_ERR_SERVER_FAILED_REQUEST,
+    PMIX_ERR_PROC_ABORTING,
+    PMIX_ERR_PROC_REQUESTED_ABORT,
+    PMIX_ERR_PROC_ABORTED,
+    PMIX_ERR_PROC_MIGRATE,
+    PMIX_ERR_PROC_CHECKPOINT,
+    PMIX_ERR_PROC_RESTART,
     PMIX_ERR_SILENT,
     PMIX_ERROR,
     PMIX_SUCCESS

--- a/src/buffer_ops/buffer_ops.h
+++ b/src/buffer_ops/buffer_ops.h
@@ -59,6 +59,7 @@ PMIX_DECLSPEC void pmix_value_load(pmix_value_t *v, void *data,
                                    pmix_data_type_t type);
 PMIX_DECLSPEC pmix_status_t pmix_value_unload(pmix_value_t *kv, void **data,
                                               size_t *sz, pmix_data_type_t type);
+PMIX_DECLSPEC bool pmix_value_cmp(pmix_value_t *p, pmix_value_t *p1);
 
 
 #define PMIX_LOAD_BUFFER(b, d, s)                       \

--- a/src/buffer_ops/copy.c
+++ b/src/buffer_ops/copy.c
@@ -166,7 +166,58 @@ int pmix_bfrop_copy_string(char **dest, char *src, pmix_data_type_t type)
 
     return PMIX_SUCCESS;
 }
-
+/* compare function for pmix_value_t*/
+bool pmix_value_cmp(pmix_value_t *p, pmix_value_t *p1)
+{
+    bool rc = false;
+    switch (p->type) {
+        case PMIX_BOOL:
+            rc = (p->data.flag == p1->data.flag);
+            break;
+        case PMIX_BYTE:
+            rc = (p->data.byte == p1->data.byte);
+            break;
+        case PMIX_SIZE:
+            rc = (p->data.size == p1->data.size);
+            break;
+        case PMIX_INT:
+            rc = (p->data.integer == p1->data.integer);
+            break;
+        case PMIX_INT8:
+            rc = (p->data.int8 == p1->data.int8);
+            break;
+        case PMIX_INT16:
+            rc = (p->data.int16 == p1->data.int16);
+            break;
+        case PMIX_INT32:
+            rc = (p->data.int32 == p1->data.int32);
+            break;
+        case PMIX_INT64:
+            rc = (p->data.int64 == p1->data.int64);
+            break;
+        case PMIX_UINT:
+            rc = (p->data.uint == p1->data.uint);
+            break;
+        case PMIX_UINT8:
+            rc = (p->data.uint8 == p1->data.int8);
+            break;
+        case PMIX_UINT16:
+            rc = (p->data.uint16 == p1->data.uint16);
+            break;
+        case PMIX_UINT32:
+            rc = (p->data.uint32 == p1->data.uint32);
+            break;
+        case PMIX_UINT64:
+            rc = (p->data.uint64 == p1->data.uint64);
+            break;
+        case PMIX_STRING:
+            rc = strcmp(p->data.string, p1->data.string);
+            break;
+        default:
+            pmix_output(0, "COMPARE-PMIX-VALUE: UNSUPPORTED TYPE %d", (int)p->type);
+    }
+    return rc;
+}
 /* COPY FUNCTIONS FOR GENERIC PMIX TYPES */
 pmix_status_t pmix_value_xfer(pmix_value_t *p, pmix_value_t *src)
 {

--- a/src/client/pmix_client_ops.h
+++ b/src/client/pmix_client_ops.h
@@ -28,6 +28,21 @@ extern pmix_client_globals_t pmix_client_globals;
 
 void pmix_client_process_nspace_blob(const char *nspace, pmix_buffer_t *bptr);
 
+void pmix_client_register_errhandler(pmix_info_t info[], size_t ninfo,
+                                     pmix_notification_fn_t errhandler,
+                                     pmix_errhandler_reg_cbfunc_t cbfunc,
+                                     void *cbdata);
+
+void pmix_client_deregister_errhandler(int errhandler_ref,
+                                       pmix_op_cbfunc_t cbfunc,
+                                       void *cbdata);
+
+pmix_status_t pmix_client_notify_error(pmix_status_t status,
+                                       pmix_proc_t procs[], size_t nprocs,
+                                       pmix_proc_t error_procs[], size_t error_nprocs,
+                                       pmix_info_t info[], size_t ninfo,
+                                       pmix_op_cbfunc_t cbfunc, void *cbdata);
+
 END_C_DECLS
 
 #endif /* PMIX_CLIENT_OPS_H */

--- a/src/common/pmix_common.c
+++ b/src/common/pmix_common.c
@@ -16,6 +16,8 @@
 #include <pmix.h>
 #include <pmix/pmix_common.h>
 #include <pmix_server.h>
+#include "src/client/pmix_client_ops.h"
+#include "src/server/pmix_server_ops.h"
 #include "src/include/pmix_globals.h"
 
 void PMIx_Register_errhandler(pmix_info_t info[], size_t ninfo,
@@ -23,14 +25,47 @@ void PMIx_Register_errhandler(pmix_info_t info[], size_t ninfo,
                               pmix_errhandler_reg_cbfunc_t cbfunc,
                               void *cbdata)
 {
-    /* common err handler registration to be added */
+    /* common err handler registration */
+    if (pmix_globals.server) {
+        /* PMIX server: store the error handler, process info keys and call
+         * cbfunc with reference to the errhandler */
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "registering server err handler");
+        pmix_server_register_errhandler(info, ninfo,
+                                        errhandler,
+                                        cbfunc,cbdata);
+
+    } else {
+        /* PMIX client: store the error handler, process info keys &
+         * call pmix_server_register_for_events, and call cbfunc with
+         * reference to the errhandler */
+         pmix_output_verbose(2, pmix_globals.debug_output,
+                             "registering client err handler");
+         pmix_client_register_errhandler(info, ninfo,
+                                        errhandler,
+                                        cbfunc, cbdata);
+    }
 }
 
 void PMIx_Deregister_errhandler(int errhandler_ref,
-                                 pmix_op_cbfunc_t cbfunc,
-                                 void *cbdata)
+                                pmix_op_cbfunc_t cbfunc,
+                                void *cbdata)
 {
-    /* common err handler deregistration goes here */
+    /* common err handler registration */
+    if (pmix_globals.server) {
+        /* PMIX server: store the error handler, process info keys and call
+         * cbfunc with reference to the errhandler */
+        pmix_server_deregister_errhandler(errhandler_ref,cbfunc,cbdata);
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "deregistering server err handler");
+    } else {
+        /* PMIX client: store the error handler, process info keys &
+         * call pmix_server_register_for_events, and call cbfunc with
+         * reference to the errhandler */
+        pmix_client_deregister_errhandler(errhandler_ref, cbfunc, cbdata);
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "deregistering client err handler");
+    }
 }
 
 pmix_status_t PMIx_Notify_error(pmix_status_t status,
@@ -39,6 +74,20 @@ pmix_status_t PMIx_Notify_error(pmix_status_t status,
                                 pmix_info_t info[], size_t ninfo,
                                 pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
-    /* common err notify goes here */
-   return PMIX_SUCCESS;
+    int rc;
+
+    if (pmix_globals.server) {
+        rc = pmix_server_notify_error(status, procs, nprocs, error_procs,
+                                      error_nprocs, info, ninfo,
+                                       cbfunc, cbdata);
+        pmix_output_verbose(0, pmix_globals.debug_output,
+                            "pmix_server_notify_error error =%d, rc=%d", status, rc);
+    } else {
+        rc = pmix_client_notify_error(status, procs, nprocs, error_procs,
+                                      error_nprocs, info, ninfo,
+                                      cbfunc, cbdata);
+        pmix_output_verbose(0, pmix_globals.debug_output,
+                            "pmix_client_notify_error error =%d, rc=%d", status, rc);
+    }
+    return rc;
 }

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -45,7 +45,6 @@ pmix_globals_t pmix_globals = {
     .pindex = 0,
     .evbase = NULL,
     .debug_output = -1,
-    .errhandler = NULL,
     .server = false,
     .connected = false,
     .cache_local = NULL,
@@ -57,6 +56,7 @@ void pmix_globals_init(void)
 {
     memset(&pmix_globals.myid, 0, sizeof(pmix_proc_t));
     PMIX_CONSTRUCT(&pmix_globals.nspaces, pmix_list_t);
+    pmix_pointer_array_init(&pmix_globals.errregs, 1, PMIX_MAX_ERROR_REGISTRATIONS, 1);
 }
 
 void pmix_globals_finalize(void)
@@ -155,3 +155,18 @@ static void info_des(pmix_rank_info_t *info)
 PMIX_CLASS_INSTANCE(pmix_rank_info_t,
                     pmix_list_item_t,
                     info_con, info_des);
+
+static void errcon(pmix_error_reg_info_t *p)
+{
+    p->errhandler = NULL;
+    p->info = NULL;
+    p->ninfo = 0;
+}
+static void errdes(pmix_error_reg_info_t *p)
+{
+    p->errhandler = NULL;
+   // PMIX_INFO_FREE(p->info, p->ninfo);
+}
+PMIX_CLASS_INSTANCE(pmix_error_reg_info_t,
+                    pmix_object_t,
+                    errcon, errdes);

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -38,7 +38,17 @@
 
 BEGIN_C_DECLS
 
-#define PMIX_MAX_CRED_SIZE  131072   // set max at 128kbytes
+#define PMIX_MAX_CRED_SIZE  131072           // set max at 128kbytes
+#define PMIX_MAX_ERROR_REGISTRATIONS    5    // maximum number of error handlers that can be registered
+
+/* define a structure for tracking error registrations */
+typedef struct {
+    pmix_object_t super;
+    pmix_notification_fn_t errhandler; /* registered err handler callback fn */
+    pmix_info_t *info;                 /* error info keys registered with the handler */
+    size_t ninfo;                      /* size of info */
+} pmix_error_reg_info_t;
+PMIX_CLASS_DECLARATION(pmix_error_reg_info_t);
 
 /* define a global construct that includes values that must be shared
  * between various parts of the code library. Both the client
@@ -51,7 +61,7 @@ typedef struct {
     int pindex;
     pmix_event_base_t *evbase;
     int debug_output;
-    pmix_notification_fn_t errhandler;
+    pmix_pointer_array_t errregs;        // my error handler registrations.
     bool server;
     bool connected;
     pmix_list_t nspaces;                 // list of pmix_nspace_t for the nspaces we know about

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -99,15 +99,22 @@ PMIX_CLASS_INSTANCE(pmix_usock_queue_t,
     pmix_value_t *vptr;
     pmix_server_caddy_t *cd;
     pmix_server_trkr_t *tracker;
-    pmix_release_cbfunc_t relfn;
-    void *relcbd;
+    union {
+       pmix_release_cbfunc_t relfn;
+       pmix_errhandler_reg_cbfunc_t errregcbfn;
+       pmix_op_cbfunc_t opcbfn;
+    }cbfunc;
+    void *cbdata;
+    int ref;
  } pmix_shift_caddy_t;
 static void scon(pmix_shift_caddy_t *p)
 {
     p->active = false;
     p->kv = NULL;
-    p->relfn = NULL;
-    p->relcbd = NULL;
+    p->cbfunc.relfn = NULL;
+    p->cbfunc.errregcbfn = NULL;
+    p->cbfunc.opcbfn = NULL;
+    p->cbdata = NULL;
 }
 static void scdes(pmix_shift_caddy_t *p)
 {
@@ -141,13 +148,11 @@ static void _queue_message(int fd, short args, void *cbdata)
 {
     pmix_usock_queue_t *queue = (pmix_usock_queue_t*)cbdata;
     pmix_usock_send_t *snd;
-
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "[%s:%d] queue callback called: reply to %s:%d on tag %d",
                         __FILE__, __LINE__,
                         (queue->peer)->info->nptr->nspace,
                         (queue->peer)->info->rank, (queue->tag));
-
     snd = PMIX_NEW(pmix_usock_send_t);
     snd->hdr.pindex = pmix_globals.pindex;
     snd->hdr.tag = (queue->tag);
@@ -234,6 +239,7 @@ static pmix_status_t initialize_server_base(pmix_server_module_t *module)
     PMIX_CONSTRUCT(&pmix_server_globals.collectives, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.remote_pnd, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.local_reqs, pmix_list_t);
+    PMIX_CONSTRUCT(&pmix_server_globals.client_eventregs, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.gdata, pmix_buffer_t);
 
     /* see if debug is requested */
@@ -271,6 +277,7 @@ static pmix_status_t initialize_server_base(pmix_server_module_t *module)
     snprintf(myaddress.sun_path, sizeof(myaddress.sun_path)-1, "%s/pmix-%d", tdir, pid);
     asprintf(&myuri, "%s:%lu:%s", pmix_globals.myid.nspace, (unsigned long)pmix_globals.myid.rank, myaddress.sun_path);
 
+
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix:server constructed uri %s", myuri);
 
@@ -303,6 +310,20 @@ pmix_status_t PMIx_server_init(pmix_server_module_t *module,
     /* create an event base and progress thread for us */
     if (NULL == (pmix_globals.evbase = pmix_start_progress_thread())) {
         return PMIX_ERR_INIT;
+    }
+
+    /* check the info keys for a directive about the uid/gid
+     * to be set for the rendezvous file */
+    if (NULL != info) {
+        for (n=0; n < ninfo; n++) {
+            if (0 == strcmp(info[n].key, PMIX_USERID)) {
+                /* the userid is in the uint32_t storage */
+                chown(myaddress.sun_path, info[n].value.data.uint32, -1);
+            } else if (0 == strcmp(info[n].key, PMIX_GRPID)) {
+               /* the grpid is in the uint32_t storage */
+                chown(myaddress.sun_path, -1, info[n].value.data.uint32);
+            }
+        }
     }
 
     /* setup the wildcard recv for inbound messages from clients */
@@ -364,6 +385,7 @@ static void cleanup_server_state(void)
     PMIX_LIST_DESTRUCT(&pmix_server_globals.collectives);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.remote_pnd);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.local_reqs);
+    PMIX_LIST_DESTRUCT(&pmix_server_globals.client_eventregs);
     PMIX_DESTRUCT(&pmix_server_globals.gdata);
 
     if (NULL != myuri) {
@@ -1035,42 +1057,80 @@ pmix_status_t PMIx_server_dmodex_request(const pmix_proc_t *proc,
     return PMIX_SUCCESS;
 }
 
+static bool match_error_registration(pmix_regevents_info_t *reginfoptr, pmix_notify_caddy_t *cd)
+{
+    unsigned int i, j;
+    char errgroup[PMIX_MAX_KEYLEN];
+    pmix_info_t *info = reginfoptr->info;
+    size_t ninfo = reginfoptr->ninfo;
+    pmix_status_t error = cd->status;
+    pmix_get_errorgroup(error, errgroup);
+    /* try to match using error name or error group keys */
+    for (i=0; i < ninfo; i++) {
+        // if we get a match on any key then we abort the search and return true.
+        if((0 == strcmp(info[i].key, PMIX_ERROR_NAME)) && (error == info[i].value.data.int32))
+            return true;
+        else if ((0 == strcmp(info[i].key, errgroup)) && (true == info[i].value.data.flag))
+            return true;
+    }
+    /* search by node (error location) key  if it is specified in the notify info list*/
+    for(i=0; i<cd->ninfo ; i++) {
+        if ( 0 == strcmp (cd->info[i].key, PMIX_ERROR_NODE_NAME)) {
+            for(j=0; j<ninfo; j++) {
+                if (( 0 == strcmp (info[j].key, PMIX_ERROR_NODE_NAME)) &&
+                    (0 == strcmp (info[j].value.data.string, cd->info[i].value.data.string)))
+                    return true;
+            }
+        }
+    }
+    /* end of search return false*/
+    return false;
+}
 
 static void _notify_error(int sd, short args, void *cbdata)
 {
     pmix_notify_caddy_t *cd = (pmix_notify_caddy_t*)cbdata;
     pmix_status_t rc;
+    pmix_cmd_t cmd = PMIX_NOTIFY_CMD;
     int i;
     size_t j;
     pmix_peer_t *peer;
-
+    pmix_regevents_info_t *reginfoptr;
+    bool notify = false;
+    pmix_output_verbose(0, pmix_globals.debug_output,
+                        "pmix_server: _notify_error notifying client of error %d",
+                        cd->status);
+    /* pack the command */
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(cd->buf, &cmd, 1, PMIX_CMD))) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
     /* pack the status */
     if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(cd->buf, &cd->status, 1, PMIX_INT))) {
         PMIX_ERROR_LOG(rc);
-        return;
+        goto cleanup;
     }
-
     /* pack the error procs */
     if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(cd->buf, &cd->error_nprocs, 1, PMIX_SIZE))) {
         PMIX_ERROR_LOG(rc);
-        return;
+        goto cleanup;
     }
     if (0 < cd->error_nprocs) {
         if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(cd->buf, cd->error_procs, cd->error_nprocs, PMIX_PROC))) {
             PMIX_ERROR_LOG(rc);
-            return;
+            goto cleanup;
         }
     }
 
     /* pack the info */
     if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(cd->buf, &cd->ninfo, 1, PMIX_SIZE))) {
         PMIX_ERROR_LOG(rc);
-        return;
+        goto cleanup;
     }
     if (0 < cd->ninfo) {
         if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(cd->buf, cd->info, cd->ninfo, PMIX_INFO))) {
             PMIX_ERROR_LOG(rc);
-            return;
+            goto cleanup;
         }
     }
 
@@ -1080,32 +1140,48 @@ static void _notify_error(int sd, short args, void *cbdata)
         if (NULL == (peer = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, i))) {
             continue;
         }
-        /* if the procs field is NULL, then send it to everyone */
-        if (NULL == cd->procs) {
+        /*get the client's error registration and check if client requested notification of
+          this error */
+        reginfoptr = NULL;
+        PMIX_LIST_FOREACH(reginfoptr, &pmix_server_globals.client_eventregs, pmix_regevents_info_t) {
+           if (reginfoptr->peer == peer) {
+                /* check if the client has registered for this error  by parsing the info keys*/
+                notify = match_error_registration(reginfoptr, cd);
+                pmix_output_verbose(2, pmix_globals.debug_output,
+                                    "pmix_server _notify_error - match error registration returned notify =%d ", notify);
+            }
+            if(notify)
+                break;
+        }
+        if (!notify) {
+            /* when the client does not specify what errors to be notified, PMIX server sends
+               it to every process in the list specified by resource manager */
+            for (j=0; j < cd->nprocs; j++) {
+                if (0 != strncmp(peer->info->nptr->nspace, cd->procs[j].nspace, PMIX_MAX_NSLEN)) {
+                    continue;
+                }
+                if (PMIX_RANK_WILDCARD == cd->procs[j].rank ||
+                    cd->procs[j].rank == peer->info->rank) {
+                    notify = true;
+                    break;
+                }
+            }
+        }
+        if (notify) {
+            pmix_output_verbose(2, pmix_globals.debug_output,
+                                "pmix_server: _notify_error - notifying process rank %d error %d",
+                                 peer->info->rank, cd->status);
             PMIX_RETAIN(cd->buf);
             PMIX_SERVER_QUEUE_REPLY(peer, 0, cd->buf);
-            continue;
-        }
-        /* otherwise, check to see if this proc is included */
-        for (j=0; j < cd->nprocs; j++) {
-            if (0 != strncmp(peer->info->nptr->nspace, cd->procs[j].nspace, PMIX_MAX_NSLEN)) {
-                continue;
-            }
-            if (PMIX_RANK_WILDCARD == cd->procs[j].rank ||
-                cd->procs[j].rank == peer->info->rank) {
-                PMIX_RETAIN(cd->buf);
-                PMIX_SERVER_QUEUE_REPLY(peer, 0, cd->buf);
-            } else {
-            }
         }
     }
+  cleanup:
     /* notify the caller */
     if (NULL != cd->cbfunc) {
-        cd->cbfunc(PMIX_SUCCESS, cd->cbdata);
+        cd->cbfunc(rc, cd->cbdata);
     }
     PMIX_RELEASE(cd);
 }
-
 
 pmix_status_t pmix_server_notify_error(pmix_status_t status,
                                 pmix_proc_t procs[], size_t nprocs,
@@ -1140,6 +1216,9 @@ pmix_status_t pmix_server_notify_error(pmix_status_t status,
     }
     cd->cbfunc = cbfunc;
     cd->cbdata = cbdata;
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix_server_notify_error status =%d, nprocs = %lu, ninfo =%lu",
+                         status, nprocs, ninfo);
 
     /* we have to push this into our event library to avoid
      * potential threading issues */
@@ -1151,11 +1230,24 @@ pmix_status_t pmix_server_notify_error(pmix_status_t status,
 
 static void reg_errhandler(int sd, short args, void *cbdata)
 {
+    int index = 0;
+    pmix_status_t rc;
     pmix_shift_caddy_t *cd = (pmix_shift_caddy_t*)cbdata;
-
-    /* need to add processing of the info arguments */
-    pmix_globals.errhandler = cd->err;
+    /* check if this handler is already registered if so return error */
+   if (PMIX_SUCCESS ==  pmix_lookup_errhandler (cd->err, &index)) {
+        /* complete request with error status and  return its original reference */
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                           "pmix_server_register_errhandler error - hdlr already registered index = %d",
+                           index);
+        cd->cbfunc.errregcbfn (PMIX_EXISTS, index, cd->cbdata);
+    } else {
+         rc = pmix_add_errhandler (cd->err, cd->info, cd->ninfo, &index);
+         pmix_output_verbose(2, pmix_globals.debug_output,
+                             "pmix_server_register_errhandler - success index =%d", index);
+         cd->cbfunc.errregcbfn (rc, index, cd->cbdata);
+    }
     cd->active = false;
+    PMIX_RELEASE(cd);
 }
 
 void pmix_server_register_errhandler(pmix_info_t info[], size_t ninfo,
@@ -1164,21 +1256,24 @@ void pmix_server_register_errhandler(pmix_info_t info[], size_t ninfo,
                               void *cbdata)
 {
     pmix_shift_caddy_t *cd;
-
     /* need to thread shift this request */
     cd = PMIX_NEW(pmix_shift_caddy_t);
     cd->info = info;
     cd->ninfo = ninfo;
     cd->err = errhandler;
+    cd->cbfunc.errregcbfn = cbfunc;
+    cd->cbdata = cbdata;
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix_server_register_errhandler shifting to server thread");
     PMIX_THREADSHIFT(cd, reg_errhandler);
-    PMIX_WAIT_FOR_COMPLETION(cd->active);
-    PMIX_RELEASE(cd);
 }
 
 static void dereg_errhandler(int sd, short args, void *cbdata)
 {
+    pmix_status_t rc;
     pmix_shift_caddy_t *cd = (pmix_shift_caddy_t*)cbdata;
-    pmix_globals.errhandler = NULL;
+    rc = pmix_remove_errhandler (cd->ref);
+    cd->cbfunc.opcbfn(rc, cd->cbdata);
     cd->active = false;
 }
 
@@ -1189,6 +1284,9 @@ void pmix_server_deregister_errhandler(int errhandler_ref,
     pmix_shift_caddy_t *cd;
     /* need to thread shift this request */
     cd = PMIX_NEW(pmix_shift_caddy_t);
+    cd->cbfunc.opcbfn = cbfunc;
+    cd->cbdata = cbdata;
+    cd->ref = errhandler_ref;
     PMIX_THREADSHIFT(cd, dereg_errhandler);
     PMIX_WAIT_FOR_COMPLETION(cd->active);
     PMIX_RELEASE(cd);
@@ -1866,8 +1964,8 @@ finish_collective:
     PMIX_RELEASE(tracker);
 
     /* we are done */
-    if (NULL != scd->relfn) {
-        scd->relfn(scd->relcbd);
+    if (NULL != scd->cbfunc.relfn) {
+        scd->cbfunc.relfn(scd->cbdata);
     }
     PMIX_RELEASE(scd);
 }
@@ -1895,8 +1993,8 @@ static void modex_cbfunc(pmix_status_t status, const char *data, size_t ndata, v
     scd->data = data;
     scd->ndata = ndata;
     scd->tracker = tracker;
-    scd->relfn = relfn;
-    scd->relcbd = relcbd;
+    scd->cbfunc.relfn = relfn;
+    scd->cbdata = relcbd;
     PMIX_THREADSHIFT(scd, _mdxcbfunc);
 }
 
@@ -2029,6 +2127,62 @@ static void cnct_cbfunc(pmix_status_t status, void *cbdata)
     PMIX_THREADSHIFT(scd, _cnct);
 }
 
+void regevents_cbfunc (pmix_status_t status, void *cbdata)
+{
+    pmix_status_t rc;
+    pmix_server_caddy_t *cd = (pmix_server_caddy_t*) cbdata;
+    pmix_regevents_info_t *reginfo, *reginfo_next;
+    pmix_buffer_t *reply;
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "server:regevents_cbfunc called status = %d", status);
+    if (PMIX_SUCCESS != status) {
+        /* need to delete the stored event reg info when server
+        nacks reg events request */
+        PMIX_LIST_FOREACH_SAFE(reginfo, reginfo_next, &pmix_server_globals.client_eventregs,
+                               pmix_regevents_info_t) {
+            if(reginfo->peer == cd->peer) {
+                pmix_list_remove_item (&pmix_server_globals.client_eventregs,
+                                       &reginfo->super);
+                PMIX_RELEASE(reginfo);
+                break;
+            }
+        }
+    }
+    reply = PMIX_NEW(pmix_buffer_t);
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(reply, &status, 1, PMIX_INT)))
+        PMIX_ERROR_LOG(rc);
+    // send reply
+    PMIX_SERVER_QUEUE_REPLY(cd->peer, cd->hdr.tag, reply);
+    PMIX_RELEASE(cd);
+}
+
+static void deregevents_cbfunc (pmix_status_t status, void *cbdata)
+{
+    pmix_status_t rc;
+    pmix_server_caddy_t *cd = (pmix_server_caddy_t*) cbdata;
+    pmix_buffer_t *reply = PMIX_NEW(pmix_buffer_t);
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "server:deregevents_cbfunc called status = %d", status);
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(reply, &status, 1, PMIX_INT)))
+        PMIX_ERROR_LOG(rc);
+    // send reply
+    PMIX_SERVER_QUEUE_REPLY(cd->peer, cd->hdr.tag, reply);
+    PMIX_RELEASE(cd);
+}
+
+static void notifyerror_cbfunc (pmix_status_t status, void *cbdata)
+{
+    pmix_status_t rc;
+    pmix_server_caddy_t *cd = (pmix_server_caddy_t*) cbdata;
+    pmix_buffer_t *reply = PMIX_NEW(pmix_buffer_t);
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "server:notifyerror_cbfunc called status = %d", status);
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(reply, &status, 1, PMIX_INT)))
+        PMIX_ERROR_LOG(rc);
+    // send reply
+    PMIX_SERVER_QUEUE_REPLY(cd->peer, cd->hdr.tag, reply);
+    PMIX_RELEASE(cd);
+}
 
 /* the switchyard is the primary message handling function. It's purpose
  * is to take incoming commands (packed into a buffer), unpack them,
@@ -2191,6 +2345,29 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag,
         return rc;
     }
 
+    if (PMIX_REGEVENTS_CMD == cmd) {
+        PMIX_PEER_CADDY(cd, peer, tag);
+        if (PMIX_SUCCESS != (rc = pmix_server_register_events(peer, buf, regevents_cbfunc, cd))) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(cd);
+        }
+        return rc;
+    }
+    if (PMIX_DEREGEVENTS_CMD == cmd) {
+        PMIX_PEER_CADDY(cd, peer, tag);
+        if (PMIX_SUCCESS != (rc = pmix_server_deregister_events(peer, buf, deregevents_cbfunc, cd))) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(cd);
+        }
+        return rc;
+    }
+    if (PMIX_NOTIFY_CMD == cmd) {
+        PMIX_PEER_CADDY(cd, peer, tag);
+        if (PMIX_SUCCESS != (rc = pmix_server_notify_error_client(peer, buf, notifyerror_cbfunc, cd))) {
+            PMIX_ERROR_LOG(rc);
+        }
+        return rc;
+    }
     return PMIX_ERR_NOT_SUPPORTED;
 }
 

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -211,7 +211,7 @@ pmix_status_t pmix_server_commit(pmix_peer_t *peer, pmix_buffer_t *buf)
             PMIX_RELEASE(dcd);
         }
     }
-    /* see if anyone local is waiting on this data - could be more than one */
+    /* see if anyone local is waiting on this data- could be more than one */
     return pmix_pending_resolve(nptr, info->rank, PMIX_SUCCESS, NULL);
 }
 
@@ -948,6 +948,173 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
     return rc;
 }
 
+pmix_status_t pmix_server_register_events(pmix_peer_t *peer,
+                                          pmix_buffer_t *buf,
+                                          pmix_op_cbfunc_t cbfunc,
+                                          void *cbdata)
+{
+    int32_t cnt;
+    pmix_status_t rc;
+    pmix_info_t *info = NULL;
+    size_t ninfo;
+    pmix_regevents_info_t *reginfo;
+
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "recvd register events");
+
+    if (NULL == pmix_host_server.register_events) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+    /* unpack the number of info objects */
+    cnt=1;
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(buf, &ninfo, &cnt, PMIX_SIZE))) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+    /* unpack the array of info objects */
+    if (0 < ninfo) {
+        PMIX_INFO_CREATE(info, ninfo);
+        cnt=ninfo;
+        if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(buf, info, &cnt, PMIX_INFO))) {
+            PMIX_ERROR_LOG(rc);
+            goto cleanup;
+        }
+    }
+    /* store the event registration info so we can call the registered
+       client when the server notifies the event */
+    reginfo = PMIX_NEW(pmix_regevents_info_t);
+    PMIX_INFO_CREATE (reginfo->info, ninfo);
+    reginfo->ninfo = ninfo;
+    for (cnt=0; cnt < ninfo; cnt++) {
+        memcpy(reginfo->info[cnt].key, info[cnt].key, PMIX_MAX_KEYLEN);
+        pmix_value_xfer(&reginfo->info[cnt].value, &info[cnt].value);
+    }
+    PMIX_RETAIN(peer);
+    reginfo->peer = peer;
+    pmix_list_append(&pmix_server_globals.client_eventregs, &reginfo->super);
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "server register events: calling host server reg events");
+    /* call the local server */
+    if(PMIX_SUCCESS != (rc = pmix_host_server.register_events(reginfo->info,
+                             reginfo->ninfo, cbfunc, cbdata)))
+    {
+
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                             "server register events: host server reg events returned rc =%d", rc);
+    }
+cleanup:
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "server register events: ninfo =%lu rc =%d", ninfo, rc);
+    PMIX_INFO_FREE(info, ninfo);
+    return rc;
+}
+
+pmix_status_t pmix_server_deregister_events(pmix_peer_t *peer,
+                                          pmix_buffer_t *buf,
+                                          pmix_op_cbfunc_t cbfunc,
+                                          void *cbdata)
+{
+    int32_t cnt;
+    pmix_status_t rc;
+    pmix_info_t *info = NULL;
+    size_t ninfo;
+    pmix_regevents_info_t *reginfo = NULL;
+    pmix_regevents_info_t *reginfo_next;
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "recvd deregister events");
+
+    if (NULL == pmix_host_server.register_events) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+    /* unpack the number of info objects */
+    cnt=1;
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(buf, &ninfo, &cnt, PMIX_SIZE))) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+    /* unpack the array of info objects */
+    if (0 < ninfo) {
+        PMIX_INFO_CREATE(info, ninfo);
+        cnt=ninfo;
+        if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(buf, info, &cnt, PMIX_INFO))) {
+            PMIX_ERROR_LOG(rc);
+            goto cleanup;
+        }
+    }
+    /* delete the stored event registration info */
+    PMIX_LIST_FOREACH_SAFE(reginfo, reginfo_next,
+                            &pmix_server_globals.client_eventregs, pmix_regevents_info_t) {
+        /* TO DO: For now assume there is one reginfo per peer, we need to revisit this
+           to match info keys too, inorder to support multiple event reg requests per process */
+        if(reginfo->peer == peer) {
+            pmix_list_remove_item (&pmix_server_globals.client_eventregs,  &reginfo->super);
+            PMIX_RELEASE(reginfo);
+            break;
+        }
+    }
+    /* call the local server */
+    rc = pmix_host_server.deregister_events(info, ninfo, cbfunc, cbdata);
+
+cleanup:
+    PMIX_INFO_FREE(info, ninfo);
+    return rc;
+}
+
+pmix_status_t pmix_server_notify_error_client(pmix_peer_t *peer,
+                                              pmix_buffer_t *buf,
+                                              pmix_op_cbfunc_t cbfunc,
+                                              void *cbdata)
+{
+    int32_t cnt;
+    pmix_status_t rc, status;
+    pmix_info_t *info = NULL;
+    size_t ninfo, nprocs;
+    pmix_proc_t *procs = NULL;
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "recvd  notify error from client");
+    /* unpack status */
+    cnt = 1;
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(buf, &status, &cnt, PMIX_INT))) {
+        PMIX_ERROR_LOG(rc);
+        goto exit;
+    }
+    /* unpack procs */
+    cnt = 1;
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(buf, &nprocs, &cnt, PMIX_SIZE))) {
+        PMIX_ERROR_LOG(rc);
+        goto exit;
+    }
+    if ( 0 < nprocs) {
+        PMIX_PROC_CREATE(procs, nprocs);
+        cnt = nprocs;
+        if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(buf, procs, &cnt, PMIX_PROC))) {
+            PMIX_PROC_FREE(procs, nprocs);
+            PMIX_ERROR_LOG(rc);
+            goto exit;
+        }
+    }
+    /* unpack the info keys */
+    cnt = 1;
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(buf, &ninfo, &cnt, PMIX_SIZE))) {
+        PMIX_ERROR_LOG(rc);
+        goto exit;
+    }
+    if (0 < ninfo) {
+        PMIX_INFO_CREATE(info, ninfo);
+        cnt = ninfo;
+        if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(buf, info, &cnt, PMIX_INFO))) {
+            PMIX_ERROR_LOG(rc);
+            goto exit;
+        }
+    }
+    pmix_errhandler_invoke(status, procs, nprocs, info, ninfo);
+exit:
+    PMIX_PROC_FREE(procs, nprocs);
+    PMIX_INFO_FREE(info, ninfo);
+    cbfunc(rc, cbdata);
+    return rc;
+}
+
 // instance server library classes
 static void tcon(pmix_server_trkr_t *t)
 {
@@ -1089,3 +1256,18 @@ PMIX_CLASS_INSTANCE(pmix_dmdx_local_t,
 PMIX_CLASS_INSTANCE(pmix_pending_connection_t,
                     pmix_object_t,
                     NULL, NULL);
+static void regcon(pmix_regevents_info_t *p)
+{
+    p->peer = NULL;
+    p->info = NULL;
+    p->ninfo = 0;
+}
+static void regdes(pmix_regevents_info_t *p)
+{
+    if(NULL != p->peer)
+        PMIX_RELEASE(p->peer);
+    PMIX_INFO_FREE(p->info, p->ninfo);
+}
+PMIX_CLASS_INSTANCE(pmix_regevents_info_t,
+                    pmix_list_item_t,
+                    regcon, regdes);

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -5,6 +5,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ *
  * $COPYRIGHT$
  */
 
@@ -137,6 +138,15 @@ typedef struct {
 } pmix_pending_connection_t;
 PMIX_CLASS_DECLARATION(pmix_pending_connection_t);
 
+/* event/error registration book keeping */
+typedef struct {
+    pmix_list_item_t super;
+    pmix_peer_t *peer;
+    pmix_info_t *info;
+    size_t ninfo;
+} pmix_regevents_info_t;
+PMIX_CLASS_DECLARATION(pmix_regevents_info_t);
+
 typedef struct {
     pmix_pointer_array_t clients;           // array of pmix_peer_t local clients
     pmix_list_t collectives;                // list of active pmix_server_trkr_t
@@ -146,6 +156,7 @@ typedef struct {
     int listen_socket;                      // socket listener is watching
     int stop_thread[2];                     // pipe used to stop listener thread
     pmix_buffer_t gdata;                    // cache of data given to me for passing to all clients
+    pmix_list_t client_eventregs;           // list of registered events per client.
 } pmix_server_globals_t;
 
 #define PMIX_PEER_CADDY(c, p, t)                \
@@ -246,6 +257,23 @@ pmix_status_t pmix_server_notify_error(pmix_status_t status,
                                        pmix_proc_t error_procs[], size_t error_nprocs,
                                        pmix_info_t info[], size_t ninfo,
                                        pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+pmix_status_t pmix_server_register_events(pmix_peer_t *peer,
+                                 pmix_buffer_t *buf,
+                                 pmix_op_cbfunc_t cbfunc,
+                                 void *cbdata);
+
+pmix_status_t pmix_server_deregister_events(pmix_peer_t *peer,
+                                          pmix_buffer_t *buf,
+                                          pmix_op_cbfunc_t cbfunc,
+                                          void *cbdata);
+
+pmix_status_t pmix_server_notify_error_client(pmix_peer_t *peer,
+                                              pmix_buffer_t *buf,
+                                              pmix_op_cbfunc_t cbfunc,
+                                              void *cbdata);
+
+void regevents_cbfunc (pmix_status_t status, void *cbdata);
 
 extern pmix_server_module_t pmix_host_server;
 extern pmix_server_globals_t pmix_server_globals;

--- a/src/usock/usock.h
+++ b/src/usock/usock.h
@@ -76,7 +76,9 @@ typedef enum {
     PMIX_SPAWNNB_CMD,
     PMIX_CONNECTNB_CMD,
     PMIX_DISCONNECTNB_CMD,
-    PMIX_NOTIFY_CMD
+    PMIX_NOTIFY_CMD,
+    PMIX_REGEVENTS_CMD,
+    PMIX_DEREGEVENTS_CMD,
 } pmix_cmd_t;
 
 
@@ -175,6 +177,8 @@ typedef struct {
     pmix_value_cbfunc_t value_cbfunc;
     pmix_lookup_cbfunc_t lookup_cbfunc;
     pmix_spawn_cbfunc_t spawn_cbfunc;
+    pmix_errhandler_reg_cbfunc_t errreg_cbfunc;
+    int errhandler_ref;
     void *cbdata;
     char nspace[PMIX_MAX_NSLEN+1];
     int rank;

--- a/src/util/error.c
+++ b/src/util/error.c
@@ -35,6 +35,7 @@
 
 #include "src/util/error.h"
 #include "src/include/pmix_globals.h"
+#include "src/buffer_ops/buffer_ops.h"
 
 const char* PMIx_Error_string(pmix_status_t errnum)
 {
@@ -122,13 +123,27 @@ const char* PMIx_Error_string(pmix_status_t errnum)
         return "INVALID-CREDENTIAL";
     case PMIX_EXISTS:
         return "EXISTS";
-
+    case PMIX_ERR_SERVER_FAILED_REQUEST:
+        return "SERVER FAILED REQUEST";
+    case PMIX_ERR_PROC_MIGRATE:
+        return "PROC-MIGRATE";
+    case PMIX_ERR_PROC_CHECKPOINT:
+        return "PROC-CHECKPOINT-ERROR";
+    case PMIX_ERR_PROC_RESTART:
+        return "PROC_RESTART";
+    case PMIX_ERR_PROC_ABORTING:
+        return "PROC-ABORTING";
+    case PMIX_ERR_PROC_REQUESTED_ABORT:
+        return "PROC-ABORT-REQUESTED";
+    case PMIX_ERR_PROC_ABORTED:
+        return "PROC-ABORTED";
     case PMIX_ERR_SILENT:
-        return "SILENT";
+        return "SILENT_ERROR";
     case PMIX_ERROR:
         return "ERROR";
     case PMIX_SUCCESS:
         return "SUCCESS";
+
     }
     return "ERROR STRING NOT FOUND";
 }
@@ -137,7 +152,132 @@ void pmix_errhandler_invoke(pmix_status_t status,
                             pmix_proc_t procs[], size_t nprocs,
                             pmix_info_t info[], size_t ninfo)
 {
-    if (NULL != pmix_globals.errhandler) {
-        pmix_globals.errhandler(status, procs, nprocs, info, ninfo);
+    /* We need to parse thru each registered handler and determine
+       which one to call for the specific error */
+    int matched_errregs[PMIX_MAX_ERROR_REGISTRATIONS];
+    int i, nmatched = 0;
+    unsigned int j,k;
+    bool exact_match = false;
+    int allerrhandler_ind = -1;
+    pmix_error_reg_info_t *errreg;
+    for (i = 0; i < pmix_pointer_array_get_size(&pmix_globals.errregs) &&
+            !exact_match; i++) {
+        errreg = (pmix_error_reg_info_t*) pmix_pointer_array_get_item (&pmix_globals.errregs, i);
+        if(0 == errreg->ninfo) {
+            // this is a general err handler we will call it if there is no better match
+            allerrhandler_ind = i;
+        } else {
+            /* match error name key first */
+            for(j = 0; j < errreg->ninfo; j++) {
+                if ((0 == strcmp(errreg->info[j].key, PMIX_ERROR_NAME)) &&
+                        (status == errreg->info[j].value.data.int32)) {
+                     matched_errregs[0] = i;
+                     nmatched = 1;
+                     exact_match = true;
+                     break;
+                } else {
+                    for (k = 0; k < errreg->ninfo; k++) {
+                        if ((0 == strcmp(errreg->info[j].key, info[k].key)) &&
+                            (pmix_value_cmp(&errreg->info[j].value, &info[k].value))) {
+                            matched_errregs[nmatched++] = 1;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    for ( i =0 ;i < nmatched; i++) {
+        errreg = (pmix_error_reg_info_t*) pmix_pointer_array_get_item (&pmix_globals.errregs,
+                                                                        matched_errregs[i]);
+        errreg->errhandler (status, procs, nprocs, info, ninfo);
+    }
+    if ( 0 == nmatched && 0 <= allerrhandler_ind) {
+        errreg = (pmix_error_reg_info_t*) pmix_pointer_array_get_item (&pmix_globals.errregs,
+                  allerrhandler_ind);
+        errreg->errhandler (status, procs, nprocs, info, ninfo);
+    }
+}
+
+pmix_status_t pmix_lookup_errhandler(pmix_notification_fn_t err,
+                                     int *index)
+{
+    int i;
+    pmix_status_t rc = PMIX_ERR_NOT_FOUND;
+    pmix_error_reg_info_t *errreg = NULL;
+    for (i = 0; i < pmix_pointer_array_get_size(&pmix_globals.errregs) ; i++) {
+        errreg = (pmix_error_reg_info_t*) pmix_pointer_array_get_item (&pmix_globals.errregs, i);
+        if((NULL != errreg) && (err == errreg->errhandler)) {
+            *index = i;
+            rc = PMIX_SUCCESS;
+            break;
+        }
+    }
+    return rc;
+}
+
+pmix_status_t pmix_add_errhandler(pmix_notification_fn_t err,
+                                  pmix_info_t *info, int ninfo,
+                                  int *index)
+{
+    int i;
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_error_reg_info_t *errreg = PMIX_NEW(pmix_error_reg_info_t);
+    errreg->errhandler = err;
+    errreg->ninfo = ninfo;
+    PMIX_INFO_CREATE(errreg->info, ninfo);
+    for (i=0; i < ninfo; i++) {
+        memcpy(errreg->info[i].key, info[i].key, PMIX_MAX_KEYLEN);
+        pmix_value_xfer(&errreg->info[i].value, &info[i].value);
+    }
+    *index = pmix_pointer_array_add (&pmix_globals.errregs, errreg);
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix_add_errhandler index =%d", *index);
+    if (-1 == *index)
+        rc = PMIX_ERROR;
+    return rc;
+}
+
+pmix_status_t pmix_remove_errhandler(int errhandler_ref)
+{
+    int rc = PMIX_SUCCESS;
+    pmix_error_reg_info_t *errreg;
+    errreg = (pmix_error_reg_info_t*) pmix_pointer_array_get_item (&pmix_globals.errregs,
+                                                                   errhandler_ref);
+    if (NULL != errreg)
+        PMIX_RELEASE(errreg);
+    else
+        rc = PMIX_ERR_NOT_FOUND;
+    return rc;
+}
+
+void pmix_get_errorgroup ( pmix_status_t status, char *pmix_error_group)
+{
+    switch(status) {
+        case PMIX_ERR_UNREACH:
+        case PMIX_ERR_COMM_FAILURE:
+        case PMIX_ERR_SERVER_NOT_AVAIL:
+        case PMIX_ERR_TIMEOUT:
+        case PMIX_ERR_PACK_FAILURE:
+        case PMIX_ERR_UNPACK_FAILURE:
+            strcpy(pmix_error_group, PMIX_ERROR_GROUP_COMM);
+            break;
+        case PMIX_ERR_OUT_OF_RESOURCE:
+        case PMIX_ERR_RESOURCE_BUSY:
+        case PMIX_ERR_NOMEM:
+            strcpy(pmix_error_group, PMIX_ERROR_GROUP_RESOURCE);
+            break;
+        case PMIX_ERR_PROC_MIGRATE:
+        case PMIX_ERR_PROC_CHECKPOINT:
+        case PMIX_ERR_PROC_RESTART:
+            strcpy(pmix_error_group, PMIX_ERROR_GROUP_MIGRATE);
+            break;
+        case PMIX_ERR_PROC_ABORTING:
+        case PMIX_ERR_PROC_REQUESTED_ABORT:
+        case PMIX_ERR_PROC_ABORTED:
+            strcpy(pmix_error_group, PMIX_ERROR_GROUP_ABORT);
+            break;
+        default:
+            strcpy(pmix_error_group, PMIX_ERROR_GROUP_GENERAL);
     }
 }

--- a/src/util/error.h
+++ b/src/util/error.h
@@ -29,7 +29,7 @@
 BEGIN_C_DECLS
 
 #define PMIX_ERROR_LOG(r)                                               \
-    do {                                                                \
+     do {                                                               \
         if (PMIX_ERR_SILENT != (r)) {                                   \
             pmix_output(0, "PMIX ERROR: %s in file %s at line %d",      \
                         PMIx_Error_string((r)), __FILE__, __LINE__);    \
@@ -45,6 +45,17 @@ BEGIN_C_DECLS
 PMIX_DECLSPEC void pmix_errhandler_invoke(pmix_status_t status,
                                           pmix_proc_t procs[], size_t nprocs,
                                           pmix_info_t info[], size_t ninfo);
+
+PMIX_DECLSPEC pmix_status_t pmix_lookup_errhandler(pmix_notification_fn_t err,
+                                                   int *index);
+
+PMIX_DECLSPEC pmix_status_t pmix_add_errhandler(pmix_notification_fn_t err,
+                                                pmix_info_t *info, int ninfo,
+                                                int *index);
+
+PMIX_DECLSPEC pmix_status_t pmix_remove_errhandler(int errhandler_ref);
+
+PMIX_DECLSPEC void pmix_get_errorgroup ( pmix_status_t status, char *pmix_error_group);
 
 END_C_DECLS
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -21,7 +21,7 @@
 
 SUBDIRS = simple
 
-headers = test_common.h cli_stages.h server_callbacks.h utils.h test_fence.h test_publish.h test_spawn.h test_cd.h test_resolve_peers.h
+headers = test_common.h cli_stages.h server_callbacks.h utils.h test_fence.h test_publish.h test_spawn.h test_cd.h test_resolve_peers.h test_error.h
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/src/api
 
@@ -48,7 +48,7 @@ pmi2_client_LDADD = \
 	$(top_builddir)/libpmix.la
 
 pmix_client_SOURCES = $(headers) \
-        pmix_client.c test_fence.c test_common.c test_publish.c test_spawn.c test_cd.c test_resolve_peers.c
+        pmix_client.c test_fence.c test_common.c test_publish.c test_spawn.c test_cd.c test_resolve_peers.c test_error.c
 pmix_client_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 pmix_client_LDADD = \
 	$(top_builddir)/libpmix.la

--- a/test/cli_stages.c
+++ b/test/cli_stages.c
@@ -249,8 +249,12 @@ void errhandler(pmix_status_t status,
                 pmix_proc_t procs[], size_t nprocs,
                 pmix_info_t info[], size_t ninfo)
 {
-    TEST_ERROR(("Error handler with status = %d", status))
-    test_abort = true;
+    TEST_ERROR((" PMIX server Error handler with status = %d", status));
+    /* notify clients of error */
+    PMIx_Notify_error(status,
+                      NULL, 0,
+                      NULL, 0, NULL, 0,
+                      op_callbk, NULL);
 }
 
 void op_callbk(pmix_status_t status,

--- a/test/pmix_client.c
+++ b/test/pmix_client.c
@@ -38,6 +38,29 @@
 #include "test_spawn.h"
 #include "test_cd.h"
 #include "test_resolve_peers.h"
+#include "test_error.h"
+
+
+static void errhandler(pmix_status_t status,
+                pmix_proc_t procs[], size_t nprocs,
+                pmix_info_t info[], size_t ninfo)
+{
+    TEST_ERROR(("PMIX client: Error handler with status = %d", status))
+}
+
+static void op_callbk(pmix_status_t status,
+               void *cbdata)
+{
+    TEST_VERBOSE(( "OP CALLBACK CALLED WITH STATUS %d", status));
+}
+
+static void errhandler_reg_callbk (pmix_status_t status,
+                            int errhandler_ref,
+                            void *cbdata)
+{
+    TEST_VERBOSE(("PMIX client ERRHANDLER REGISTRATION CALLBACK CALLED WITH STATUS %d, ref=%d",
+                  status, errhandler_ref));
+}
 
 int main(int argc, char **argv)
 {
@@ -64,7 +87,7 @@ int main(int argc, char **argv)
         FREE_TEST_PARAMS(params);
         exit(0);
     }
-
+    PMIx_Register_errhandler(NULL, 0, errhandler, errhandler_reg_callbk, NULL);
     if (myproc.rank != params.rank) {
         TEST_ERROR(("Client ns %s Rank returned in PMIx_Init %d does not match to rank from command line %d.", myproc.nspace, myproc.rank, params.rank));
         FREE_TEST_PARAMS(params);
@@ -156,8 +179,17 @@ int main(int argc, char **argv)
         }
     }
 
-    TEST_VERBOSE(("Client ns %s rank %d: PASSED", myproc.nspace, myproc.rank));
+    if (0 != params.test_error) {
+        rc = test_error(myproc.nspace, myproc.rank, params);
+        if (PMIX_SUCCESS != rc) {
+            FREE_TEST_PARAMS(params);
+            TEST_ERROR(("%s:%d error registration and event handling test failed: %d", myproc.nspace, myproc.rank, rc));
+            exit(0);
+        }
+    }
 
+    TEST_VERBOSE(("Client ns %s rank %d: PASSED", myproc.nspace, myproc.rank));
+    PMIx_Deregister_errhandler(1, op_callbk, NULL);
     /* finalize us */
     TEST_VERBOSE(("Client ns %s rank %d: Finalizing", myproc.nspace, myproc.rank));
     if (PMIX_SUCCESS != (rc = PMIx_Finalize())) {

--- a/test/server_callbacks.c
+++ b/test/server_callbacks.c
@@ -27,6 +27,8 @@ pmix_server_module_t mymodule = {
     spawn_fn,
     connect_fn,
     disconnect_fn,
+    regevents_fn,
+    deregevents_fn,
     NULL
 };
 
@@ -300,3 +302,22 @@ int disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
     return PMIX_SUCCESS;
 }
 
+int regevents_fn (const pmix_info_t info[], size_t ninfo,
+                  pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    TEST_VERBOSE ((" pmix host server regevents_fn called "));
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+    return PMIX_SUCCESS;
+}
+
+int deregevents_fn (const pmix_info_t info[], size_t ninfo,
+                  pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    TEST_VERBOSE ((" pmix host server deregevents_fn called "));
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+    return PMIX_SUCCESS;
+}

--- a/test/server_callbacks.h
+++ b/test/server_callbacks.h
@@ -49,7 +49,10 @@ pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
 pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
                             const pmix_info_t info[], size_t ninfo,
                             pmix_op_cbfunc_t cbfunc, void *cbdata);
-
+pmix_status_t regevents_fn(const pmix_info_t info[], size_t ninfo,
+                            pmix_op_cbfunc_t cbfunc, void *cbdata);
+pmix_status_t deregevents_fn(const pmix_info_t info[], size_t ninfo,
+                           pmix_op_cbfunc_t cbfunc, void *cbdata);
 extern pmix_server_module_t mymodule;
 
 #endif

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -76,6 +76,7 @@ void parse_cmd(int argc, char **argv, test_params *params)
             fprintf(stderr, "\t--test-spawn       test spawn api.\n");
             fprintf(stderr, "\t--test-connect     test connect/disconnect api.\n");
             fprintf(stderr, "\t--test-resolve-peers    test resolve_peers api.\n");
+            fprintf(stderr, "t--test-error test error handling api.\n");
             exit(0);
         } else if (0 == strcmp(argv[i], "--exec") || 0 == strcmp(argv[i], "-e")) {
             i++;
@@ -166,6 +167,8 @@ void parse_cmd(int argc, char **argv, test_params *params)
             params->test_connect = 1;
         } else if( 0 == strcmp(argv[i], "--test-resolve-peers") ){
             params->test_resolve_peers = 1;
+        } else if( 0 == strcmp(argv[i], "--test-error") ){
+            params->test_error = 1;
         }
 
         else {

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -116,6 +116,7 @@ typedef struct {
     int test_spawn;
     int test_connect;
     int test_resolve_peers;
+    int test_error;
 } test_params;
 
 #define INIT_TEST_PARAMS(params) do { \
@@ -143,6 +144,7 @@ typedef struct {
     params.fences = NULL;             \
     params.noise = NULL;              \
     params.ns_dist = NULL;            \
+    params.test_error = 0;            \
 } while (0)
 
 #define FREE_TEST_PARAMS(params) do { \

--- a/test/test_error.c
+++ b/test/test_error.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2015      Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+#include <time.h>
+#include "test_error.h"
+#include "test_common.h"
+
+#define MAX_ERR_HANDLERS 5
+#define TEST_NOTIFY PMIX_ERR_TIMEOUT
+static bool done;
+static void comfail_errhandler(pmix_status_t status,
+                                pmix_proc_t procs[], size_t nprocs,
+                                pmix_info_t info[], size_t ninfo)
+{
+    TEST_ERROR(("comfail errhandler called for error status = %d nprocs =%d ninfo = %d",
+                  status, nprocs, ninfo));
+}
+
+static void timeout_errhandler(pmix_status_t status,
+                               pmix_proc_t procs[], size_t nprocs,
+                               pmix_info_t info[], size_t ninfo)
+{
+    TEST_ERROR(("timeout errhandler called for error status = %d nprocs = %d ninfo = %d",
+                  status, nprocs, ninfo));
+}
+
+static void op1_callbk(pmix_status_t status,
+                                   void *cbdata)
+{
+    TEST_VERBOSE(( "op1_callbk CALLED WITH STATUS %d", status));
+    done = true;
+}
+
+static void errhandler_reg_callbk1 (pmix_status_t status,
+                                   int errhandler_ref,
+                                   void *cbdata)
+{
+    int *ref = (int*) cbdata;
+    *ref = errhandler_ref;
+    TEST_VERBOSE(("PMIX client ERRHANDLER REGISTRATION CALLED WITH STATUS %d, ref=%d",
+                  status, *ref, errhandler_ref));
+
+}
+
+int test_error(char *my_nspace, int my_rank, test_params params)
+{
+    pmix_info_t *info;
+    size_t ninfo;
+    int errhandler_refs[MAX_ERR_HANDLERS];
+    int value;
+    struct timespec ts;
+    TEST_VERBOSE(("test-error: running  error handling test cases"));
+    /* register specific client error handlers and test their invocation
+     * by  trigerring events  from server side*/
+    ninfo = 1;
+    value = PMIX_ERR_TIMEOUT;
+    PMIX_INFO_CREATE(info, ninfo);
+    (void)strncpy(info[0].key, PMIX_ERROR_NAME, PMIX_MAX_KEYLEN);
+    pmix_value_load(&info[0].value, &value, PMIX_INT);
+    PMIx_Register_errhandler(info, 1, timeout_errhandler, errhandler_reg_callbk1, &errhandler_refs[0]);
+    /* reg a handler for comm errors */
+    (void)strncpy(info[0].key, PMIX_ERROR_GROUP_COMM, PMIX_MAX_KEYLEN);
+    value = 1;
+    pmix_value_load(&info[0].value, &value, PMIX_BOOL);
+    PMIx_Register_errhandler(info, 1, comfail_errhandler, errhandler_reg_callbk1, &errhandler_refs[1]);
+    /* inject error from client */
+    done = false;
+    /* change error value to test other error notifications */
+    PMIx_Notify_error(TEST_NOTIFY,
+                      NULL, 0,
+                      NULL, 0, NULL, 0,
+                      op1_callbk, NULL);
+    while(!done) {
+        ts.tv_sec = 0;
+        ts.tv_nsec = 100000;
+        nanosleep(&ts, NULL);
+    }
+    done = false;
+    /* dereg all handlers*/
+    PMIx_Deregister_errhandler( errhandler_refs[0], op1_callbk, NULL);
+    /* loop until we get callback */
+    while(!done) {
+        ts.tv_sec = 0;
+        ts.tv_nsec = 100000;
+        nanosleep(&ts, NULL);
+    }
+    done = false;
+    PMIx_Deregister_errhandler( errhandler_refs[1], op1_callbk, NULL);
+    /* loop until we get callback */
+    while(!done) {
+        ts.tv_sec = 0;
+        ts.tv_nsec = 100000;
+        nanosleep(&ts, NULL);
+    }
+    return PMIX_SUCCESS;
+}

--- a/test/test_error.h
+++ b/test/test_error.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2015      Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include <private/autogen/config.h>
+#include <pmix.h>
+
+#include "test_common.h"
+
+int test_error(char *my_nspace, int my_rank, test_params params);

--- a/test/utils.c
+++ b/test/utils.c
@@ -142,6 +142,9 @@ void set_client_argv(test_params *params, char ***argv)
     if (params->test_resolve_peers) {
         pmix_argv_append_nosize(argv, "--test-resolve-peers");
     }
+    if (params->test_error) {
+        pmix_argv_append_nosize(argv, "--test-error");
+    }
 }
 
 int launch_clients(int num_procs, char *binary, char *** client_env, char ***base_argv)


### PR DESCRIPTION
Changes include

    support to register multiple error handler in client and server.
    notify errors from server to client and vice versa.
    select error handler for the error occurred.
    fixed bugs in server error notify

NOTE: Fix the merge conflicts on Annu's PR and remove it from the master repo. I'm hanging it off of my fork of the master.