### PR TITLE
Pr/add wildcard

### DIFF
--- a/include/pmix/pmix_common.h
+++ b/include/pmix/pmix_common.h
@@ -66,6 +66,7 @@ BEGIN_C_DECLS
 
 /* define a *wildcard* value for requests involving rank */
 #define PMIX_RANK_WILDCARD -1
+#define PMIX_RANK_ZERO     -2
 
 /* define a set of "standard" PMIx attributes that can
  * be queried. Implementations (and users) are free to extend as

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -1124,8 +1124,8 @@ void pmix_client_process_nspace_blob(const char *nspace, pmix_buffer_t *bptr)
             PMIX_DESTRUCT(&buf2);  // releases the original kptr data
         } else {
             /* this is job-level data, so just add it to that hash_table
-             * with the wildcard rank */
-            if (PMIX_SUCCESS != (rc = pmix_hash_store(&nsptr->internal, PMIX_RANK_WILDCARD, kptr))) {
+             * with the universal rank identifier as PMIX_RANK_ZERO */
+            if (PMIX_SUCCESS != (rc = pmix_hash_store(&nsptr->internal, PMIX_RANK_ZERO, kptr))) {
                 PMIX_ERROR_LOG(rc);
             }
             /* maintain accounting - but note that the kptr remains

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -377,9 +377,10 @@ static void _getnbfn(int fd, short flags, void *cbdata)
          goto request;
     }
 
-    /* the requested data could be in the job-data table, so let's
-     * just check there first.  */
-    if (PMIX_SUCCESS == (rc = pmix_hash_fetch(&nptr->internal, PMIX_RANK_WILDCARD, cb->key, &val))) {
+    /* always check job-data at the beginning
+     * the requested data could be in the job-data table, so let's
+     * just check there first. */
+    if (PMIX_SUCCESS == (rc = pmix_hash_fetch(&nptr->internal, PMIX_RANK_ZERO, cb->key, &val))) {
         /* found it - we are in an event, so we can
          * just execute the callback */
         cb->value_cbfunc(rc, val, cb->cbdata);
@@ -390,7 +391,7 @@ static void _getnbfn(int fd, short flags, void *cbdata)
         PMIX_RELEASE(cb);
         return;
     }
-    if (PMIX_RANK_WILDCARD == cb->rank) {
+    if (PMIX_RANK_ZERO == cb->rank) {
         /* can't be anywhere else */
         cb->value_cbfunc(PMIX_ERR_NOT_FOUND, NULL, cb->cbdata);
         PMIX_RELEASE(cb);

--- a/test/pmi2_client.c
+++ b/test/pmi2_client.c
@@ -91,7 +91,8 @@ int main(int argc, char **argv)
         return rc;
     }
 
-    if (!ti || 1 == ti) {
+    /* this test should be always run */
+    if (1) {
         rc = test_item1();
         ret += (rc ? 1 : 0);
         log_info("TI1  : %s\n", (rc ? "FAIL" : "PASS"));
@@ -156,7 +157,6 @@ int main(int argc, char **argv)
 static int test_item1(void)
 {
     int rc = 0;
-    int val = 0;
 
     log_info("spawned=%d size=%d rank=%d appnum=%d\n", spawned, size, rank, appnum);
 
@@ -174,6 +174,16 @@ static int test_item1(void)
     log_info("jobid=%s\n", jobid);
     log_assert(memcmp(jobid, __FUNCTION__, sizeof(__FUNCTION__)), "");
 
+    return rc;
+}
+
+static int test_item2(void)
+{
+    int rc = 0;
+    int val = 0;
+
+    log_assert(PMI2_Initialized(), "");
+
     val = random_value(10, 100);
     if (PMI2_SUCCESS != (rc = PMI2_Job_GetRank(&val))) {
         log_fatal("PMI2_Job_GetRank failed: %d\n", rc);
@@ -187,15 +197,6 @@ static int test_item1(void)
         return rc;
     }
     log_assert(0 < val, "");
-
-    return rc;
-}
-
-static int test_item2(void)
-{
-    int rc = 0;
-
-    log_assert(PMI2_Initialized(), "");
 
     return rc;
 }

--- a/test/pmi_client.c
+++ b/test/pmi_client.c
@@ -336,8 +336,23 @@ static int test_item5(void)
 static int test_item6(void)
 {
     int rc = 0;
+    char nspace[100];
 
     log_error("pmix does not support this functionality\n");
+    return rc;
+    if (0 == rank) {
+        if (PMI_SUCCESS != (rc = PMI_KVS_Create(nspace, sizeof(nspace)))) {
+            log_fatal("PMI_KVS_Create failed: %d\n", rc);
+            return rc;
+        }
+        log_info("nspace=%s\n", nspace);
+
+        if (PMI_SUCCESS != (rc = PMI_KVS_Destroy(nspace))) {
+            log_fatal("PMI_KVS_Destroy failed: %d\n", rc);
+            return rc;
+        }
+    }
+
     return rc;
 }
 


### PR DESCRIPTION
@rhc54 @artpol84 could you look at one if you see any issues with such changes

This PR introduce special rank constant as PMIX_RANK_ZERO.

Now we use PMIX_RANK_WILDCARD to save job-level data and to demonstrate that we do something for any ranks.
I think that such usage have following disadvantages as
1. I believe that many people can interpreter one as any rank directive. So probably we will get related questions and issues;
2. Having this usage makes PMIx_Get_nb() function logic inconsistent because a user can set any value for proc.rank to get predefined internal keys stored with  PMIX_RANK_WILDCARD.
3. There are cases when we would like to get a key w/o information about rank. It requires to do a call to get PMIX_JOB_SIZE and a search for all ranks. I think that it could be done internally in pmix library more effective. As an example: PMI2_KVS_Get and PMI_KVS_Get allows to get a key w/o rank.

The suggestion is not only to change current wildcard name. But also have another wildcard to tell PMIx_Get that we want to look for the specific key in all ranks blobs.