### PR TITLE
dist: do not include include/private/autogen/config.h in dist tarball

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,5 +1,7 @@
 #
 # Copyright 2015-2016 Intel, Inc. All rights reserved
+# Copyright 2016      Research Organization for Information Science
+#                     and Technology (RIST). All rights reserved.
 #
 # $COPYRIGHT$
 #


### PR DESCRIPTION
this file is  automatically generated from include/private/autogen/config.h.in