### PR TITLE
Add a "required" flag to the pmix_info_t structure

### DIFF
--- a/include/pmix/pmix_common.h
+++ b/include/pmix/pmix_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2016 Intel, Inc. All rights reserved
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -504,6 +504,7 @@ extern void pmix_value_load(pmix_value_t *v, void *data,
 /****    PMIX INFO STRUCT    ****/
 typedef struct {
     char key[PMIX_MAX_KEYLEN+1];  // ensure room for the NULL terminator
+    bool required;                // defaults to optional (i.e., required=false)
     pmix_value_t value;
 } pmix_info_t;
 
@@ -541,7 +542,10 @@ typedef struct {
         (void)strncpy((m)->key, (k), PMIX_MAX_KEYLEN);  \
         pmix_value_load(&((m)->value), (v), (t));       \
     } while(0);
-
+#define PMIX_INFO_REQUIRED(m)       \
+    (m)->required = true;
+#define PMIX_INFO_OPTIONAL(m)       \
+    (m)->required = false;
 
 /****    PMIX LOOKUP RETURN STRUCT    ****/
 typedef struct {

--- a/src/buffer_ops/copy.c
+++ b/src/buffer_ops/copy.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -343,6 +343,7 @@ int pmix_bfrop_copy_info(pmix_info_t **dest, pmix_info_t *src,
 {
     *dest = (pmix_info_t*)malloc(sizeof(pmix_info_t));
     (void)strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
+    (*dest)->required = src->required;
     return pmix_value_xfer(&(*dest)->value, &src->value);
 }
 

--- a/src/buffer_ops/pack.c
+++ b/src/buffer_ops/pack.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
@@ -561,6 +561,10 @@ int pmix_bfrop_pack_info(pmix_buffer_t *buffer, const void *src,
         /* pack key */
         foo = info[i].key;
         if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_string(buffer, &foo, 1, PMIX_STRING))) {
+            return ret;
+        }
+        /* pack required flag */
+        if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_bool(buffer, &info[i].required, 1, PMIX_BOOL))) {
             return ret;
         }
         /* pack the type */

--- a/src/buffer_ops/print.c
+++ b/src/buffer_ops/print.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -648,8 +648,8 @@ int pmix_bfrop_print_info(char **output, char *prefix,
     char *tmp;
 
     pmix_bfrop_print_value(&tmp, NULL, &src->value, PMIX_VALUE);
-    asprintf(output, "%sKEY: %s %s", prefix, src->key,
-             (NULL == tmp) ? "NULL" : tmp);
+    asprintf(output, "%sKEY: %s REQD: %s %s", prefix, src->key,
+             src->required ? "Y" : "N", (NULL == tmp) ? "PMIX_VALUE: NULL" : tmp);
     if (NULL != tmp) {
         free(tmp);
     }

--- a/src/buffer_ops/unpack.c
+++ b/src/buffer_ops/unpack.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
@@ -672,6 +672,11 @@ int pmix_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
         }
         (void)strncpy(ptr[i].key, tmp, PMIX_MAX_KEYLEN);
         free(tmp);
+        /* unpack the required flag */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_bool(buffer, &ptr[i].required, &m, PMIX_BOOL))) {
+            return ret;
+        }
         /* unpack value - since the value structure is statically-defined
          * instead of a pointer in this struct, we directly unpack it to
          * avoid the malloc */


### PR DESCRIPTION
Add a "required" flag to the pmix_info_t structure so users can indicate that a specific info_t is required vs optional. We need atomicity at the individual key level, and making both "reqd" and "optional" versions of every key isn't really practical.