### PR TITLE
Replace the "required" boolean in the pmix_info_t struct with a flag-based approach

### DIFF
--- a/src/buffer_ops/copy.c
+++ b/src/buffer_ops/copy.c
@@ -85,7 +85,7 @@ int pmix_bfrop_std_copy(void **dest, void *src, pmix_data_type_t type)
     size_t datasize;
     uint8_t *val = NULL;
 
-    switch(type) {
+    switch(PMIX_GET_TYPE(type)) {
     case PMIX_BOOL:
         datasize = sizeof(bool);
         break;
@@ -166,11 +166,11 @@ int pmix_bfrop_copy_string(char **dest, char *src, pmix_data_type_t type)
 
     return PMIX_SUCCESS;
 }
-/* compare function for pmix_value_t*/
+/* compare function for pmix_value_t */
 bool pmix_value_cmp(pmix_value_t *p, pmix_value_t *p1)
 {
     bool rc = false;
-    switch (p->type) {
+    switch (PMIX_GET_TYPE(p->type)) {
         case PMIX_BOOL:
             rc = (p->data.flag == p1->data.flag);
             break;
@@ -225,7 +225,7 @@ pmix_status_t pmix_value_xfer(pmix_value_t *p, pmix_value_t *src)
 
     /* copy the right field */
     p->type = src->type;
-    switch (src->type) {
+    switch (PMIX_GET_TYPE(p->type)) {
     case PMIX_BOOL:
         p->data.flag = src->data.flag;
         break;
@@ -343,7 +343,6 @@ int pmix_bfrop_copy_info(pmix_info_t **dest, pmix_info_t *src,
 {
     *dest = (pmix_info_t*)malloc(sizeof(pmix_info_t));
     (void)strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
-    (*dest)->required = src->required;
     return pmix_value_xfer(&(*dest)->value, &src->value);
 }
 

--- a/src/buffer_ops/pack.c
+++ b/src/buffer_ops/pack.c
@@ -412,7 +412,7 @@ static int pack_val(pmix_buffer_t *buffer,
 {
     int ret;
 
-    switch (p->type) {
+    switch (PMIX_GET_TYPE(p->type)) {
     case PMIX_BOOL:
         if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_buffer(buffer, &p->data.flag, 1, PMIX_BOOL))) {
             return ret;
@@ -561,10 +561,6 @@ int pmix_bfrop_pack_info(pmix_buffer_t *buffer, const void *src,
         /* pack key */
         foo = info[i].key;
         if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_string(buffer, &foo, 1, PMIX_STRING))) {
-            return ret;
-        }
-        /* pack required flag */
-        if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_bool(buffer, &info[i].required, 1, PMIX_BOOL))) {
             return ret;
         }
         /* pack the type */

--- a/src/buffer_ops/print.c
+++ b/src/buffer_ops/print.c
@@ -551,89 +551,90 @@ int pmix_bfrop_print_value(char **output, char *prefix,
     char *prefx;
 
     /* deal with NULL prefix */
-    if (NULL == prefix) asprintf(&prefx, " ");
-    else prefx = prefix;
+    if (NULL == prefix) {
+        asprintf(&prefx, " PMIX_VALUE: Flags: %x ", PMIX_GET_FLAGS(type));
+    } else {
+        asprintf(&prefx, "%sPMIX_VALUE: Flags: %x ", prefix, PMIX_GET_FLAGS(type));
+    }
 
     /* if src is NULL, just print data type and return */
     if (NULL == src) {
         asprintf(output, "%sData type: PMIX_VALUE\tValue: NULL pointer", prefx);
-        if (prefx != prefix) {
-            free(prefx);
-        }
+        free(prefx);
         return PMIX_SUCCESS;
     }
 
-    switch (src->type) {
+    switch (PMIX_GET_TYPE(src->type)) {
     case PMIX_BYTE:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_BYTE\tValue: %x",
+        asprintf(output, "%sData type: PMIX_BYTE\tValue: %x",
                  prefx, src->data.byte);
         break;
     case PMIX_STRING:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_STRING\tValue: %s",
+        asprintf(output, "%sData type: PMIX_STRING\tValue: %s",
                  prefx, src->data.string);
         break;
     case PMIX_SIZE:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_SIZE\tValue: %lu",
+        asprintf(output, "%sData type: PMIX_SIZE\tValue: %lu",
                  prefx, (unsigned long)src->data.size);
         break;
     case PMIX_PID:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PID\tValue: %lu",
+        asprintf(output, "%sData type: PMIX_PID\tValue: %lu",
                  prefx, (unsigned long)src->data.pid);
         break;
     case PMIX_INT:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT\tValue: %d",
+        asprintf(output, "%sData type: PMIX_INT\tValue: %d",
                  prefx, src->data.integer);
         break;
     case PMIX_INT8:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT8\tValue: %d",
+        asprintf(output, "%sData type: PMIX_INT8\tValue: %d",
                  prefx, (int)src->data.int8);
         break;
     case PMIX_INT16:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT16\tValue: %d",
+        asprintf(output, "%sData type: PMIX_INT16\tValue: %d",
                  prefx, (int)src->data.int16);
         break;
     case PMIX_INT32:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT32\tValue: %d",
+        asprintf(output, "%sData type: PMIX_INT32\tValue: %d",
                  prefx, src->data.int32);
         break;
     case PMIX_INT64:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT64\tValue: %ld",
+        asprintf(output, "%sData type: PMIX_INT64\tValue: %ld",
                  prefx, (long)src->data.int64);
         break;
     case PMIX_UINT:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT\tValue: %u",
+        asprintf(output, "%sData type: PMIX_UINT\tValue: %u",
                  prefx, src->data.uint);
         break;
     case PMIX_UINT8:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT8\tValue: %u",
+        asprintf(output, "%sData type: PMIX_UINT8\tValue: %u",
                  prefx, (unsigned int)src->data.uint8);
         break;
     case PMIX_UINT16:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT16\tValue: %u",
+        asprintf(output, "%sData type: PMIX_UINT16\tValue: %u",
                  prefx, (unsigned int)src->data.uint16);
         break;
     case PMIX_UINT32:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT32\tValue: %u",
+        asprintf(output, "%sData type: PMIX_UINT32\tValue: %u",
                  prefx, src->data.uint32);
         break;
     case PMIX_UINT64:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT64\tValue: %lu",
+        asprintf(output, "%sData type: PMIX_UINT64\tValue: %lu",
                  prefx, (unsigned long)src->data.uint64);
         break;
     case PMIX_FLOAT:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_FLOAT\tValue: %f",
+        asprintf(output, "%sData type: PMIX_FLOAT\tValue: %f",
                  prefx, src->data.fval);
         break;
     case PMIX_DOUBLE:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_DOUBLE\tValue: %f",
+        asprintf(output, "%sData type: PMIX_DOUBLE\tValue: %f",
                  prefx, src->data.dval);
         break;
     case PMIX_TIMEVAL:
-        asprintf(output, "%sPMIX_VALUE: Data type: PMIX_TIMEVAL\tValue: %ld.%06ld", prefx,
+        asprintf(output, "%sData type: PMIX_TIMEVAL\tValue: %ld.%06ld", prefx,
                  (long)src->data.tv.tv_sec, (long)src->data.tv.tv_usec);
         break;
     default:
-        asprintf(output, "%sPMIX_VALUE: Data type: UNKNOWN\tValue: UNPRINTABLE", prefx);
+        asprintf(output, "%sData type: UNKNOWN\tValue: UNPRINTABLE", prefx);
         break;
     }
     if (prefx != prefix) {
@@ -648,8 +649,8 @@ int pmix_bfrop_print_info(char **output, char *prefix,
     char *tmp;
 
     pmix_bfrop_print_value(&tmp, NULL, &src->value, PMIX_VALUE);
-    asprintf(output, "%sKEY: %s REQD: %s %s", prefix, src->key,
-             src->required ? "Y" : "N", (NULL == tmp) ? "PMIX_VALUE: NULL" : tmp);
+    asprintf(output, "%sKEY: %s %s", prefix, src->key,
+             (NULL == tmp) ? "PMIX_VALUE: NULL" : tmp);
     if (NULL != tmp) {
         free(tmp);
     }

--- a/src/buffer_ops/unpack.c
+++ b/src/buffer_ops/unpack.c
@@ -511,7 +511,7 @@ static pmix_status_t unpack_val(pmix_buffer_t *buffer, pmix_value_t *val)
     pmix_status_t ret;
 
     m = 1;
-    switch (val->type) {
+    switch (PMIX_GET_TYPE(val->type)) {
     case PMIX_BOOL:
         if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_buffer(buffer, &val->data.flag, &m, PMIX_BOOL))) {
             return ret;
@@ -672,11 +672,6 @@ int pmix_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
         }
         (void)strncpy(ptr[i].key, tmp, PMIX_MAX_KEYLEN);
         free(tmp);
-        /* unpack the required flag */
-        m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_bool(buffer, &ptr[i].required, &m, PMIX_BOOL))) {
-            return ret;
-        }
         /* unpack value - since the value structure is statically-defined
          * instead of a pointer in this struct, we directly unpack it to
          * avoid the malloc */

--- a/src/client/pmi1.c
+++ b/src/client/pmi1.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
@@ -64,7 +64,6 @@ int PMI_Init(int *spawned)
     pmix_value_t *val;
     pmix_proc_t proc;
     pmix_info_t info[1];
-    bool  val_optinal = 1;
 
     if (PMIX_SUCCESS != PMIx_Init(&myproc)) {
         return PMI_ERR_INIT;
@@ -78,7 +77,7 @@ int PMI_Init(int *spawned)
      * PMIX_OPTIONAL - expect that these keys should be available on startup
      */
     PMIX_INFO_CONSTRUCT(&info[0]);
-    PMIX_INFO_LOAD(&info[0], PMIX_OPTIONAL, &val_optinal, PMIX_BOOL);
+    PMIX_INFO_LOAD(&info[0], PMIX_OPTIONAL, NULL, PMIX_BOOL);
 
     if (NULL != spawned) {
         /* get the spawned flag */
@@ -93,6 +92,7 @@ int PMI_Init(int *spawned)
             *spawned = 0;
         }
     }
+    PMIX_INFO_DESTRUCT(&info[0]);
     pmi_init = 1;
 
     rc = PMIX_SUCCESS;
@@ -209,7 +209,7 @@ int PMI_KVS_Get( const char kvsname[], const char key[], char value[], int lengt
 
     rc = PMIx_Get(&proc, key, NULL, 0, &val);
     if (PMIX_SUCCESS == rc && NULL != val) {
-        if (PMIX_STRING != val->type) {
+        if (PMIX_STRING != PMIX_GET_TYPE(val->type)) {
             rc = PMIX_ERROR;
         } else if (NULL != val->data.string) {
             (void)strncpy(value, val->data.string, length);
@@ -418,7 +418,7 @@ int PMI_Lookup_name(const char service_name[], char port[])
     }
 
     /* should have received a string back */
-    if (PMIX_STRING != pdata.value.type || NULL == pdata.value.data.string) {
+    if (PMIX_STRING != PMIX_GET_TYPE(pdata.value.type)|| NULL == pdata.value.data.string) {
         return convert_err(PMIX_ERR_NOT_FOUND);
     }
 
@@ -695,7 +695,7 @@ int PMI_Get_options(char *str, int *length)
 /* internal function */
 static pmix_status_t convert_int(int *value, pmix_value_t *kv)
 {
-    switch (kv->type) {
+    switch (PMIX_GET_TYPE(kv->type)) {
     case PMIX_INT:
         *value = kv->data.integer;
         break;

--- a/src/client/pmi2.c
+++ b/src/client/pmi2.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
@@ -246,7 +246,7 @@ int PMI2_KVS_Get(const char *jobid, int src_pmi_id,
 
     rc = PMIx_Get(&proc, key, NULL, 0, &val);
     if (PMIX_SUCCESS == rc && NULL != val) {
-        if (PMIX_STRING != val->type) {
+        if (PMIX_STRING != PMIX_GET_TYPE(val->type)) {
             rc = PMIX_ERROR;
         } else if (NULL != val->data.string) {
             (void)strncpy(value, val->data.string, maxvalue);
@@ -280,7 +280,7 @@ int PMI2_Info_GetNodeAttr(const char name[], char value[], int valuelen, int *fo
     *found = 0;
     rc = PMIx_Get(&myproc, name, info, 1, &val);
     if (PMIX_SUCCESS == rc && NULL != val) {
-        if (PMIX_STRING != val->type) {
+        if (PMIX_STRING != PMIX_GET_TYPE(val->type)) {
             rc = PMIX_ERROR;
         } else if (NULL != val->data.string) {
             (void)strncpy(value, val->data.string, valuelen);
@@ -341,7 +341,7 @@ int PMI2_Info_GetJobAttr(const char name[], char value[], int valuelen, int *fou
     *found = 0;
     rc = PMIx_Get(&proc, name, info, 1, &val);
     if (PMIX_SUCCESS == rc && NULL != val) {
-        if (PMIX_STRING != val->type) {
+        if (PMIX_STRING != PMIX_GET_TYPE(val->type)) {
             rc = PMIX_ERROR;
         } else if (NULL != val->data.string) {
             (void)strncpy(value, val->data.string, valuelen);
@@ -456,7 +456,7 @@ int PMI2_Nameserv_lookup(const char service_name[], const PMI_keyval_t *info_ptr
     }
 
     /* should have received a string back */
-    if (PMIX_STRING != pdata[0].value.type ||
+    if (PMIX_STRING != PMIX_GET_TYPE(pdata[0].value.type) ||
         NULL == pdata[0].value.data.string) {
         PMIX_PDATA_DESTRUCT(&pdata[0]);
         PMIX_PDATA_DESTRUCT(&pdata[1]);
@@ -621,7 +621,7 @@ int PMI2_Job_Spawn(int count, const char * cmds[],
 
 static pmix_status_t convert_int(int *value, pmix_value_t *kv)
 {
-    switch(kv->type) {
+    switch(PMIX_GET_TYPE(kv->type)) {
     case PMIX_INT:
         *value = kv->data.integer;
         break;

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -617,7 +617,7 @@ pmix_status_t PMIx_Put(pmix_scope_t scope, const char key[], pmix_value_t *val)
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: executing put for key %s type %d",
-                        key, val->type);
+                        key, PMIX_GET_TYPE(val->type));
 
     if (pmix_globals.init_cntr <= 0) {
         return PMIX_ERR_INIT;

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
@@ -413,7 +413,7 @@ static void _getnbfn(int fd, short flags, void *cbdata)
                 /* since we didn't provide them with a key, the hash function
                  * must return the results in the pmix_info_array field of the
                  * value */
-                if (NULL == val || PMIX_INFO_ARRAY != val->type) {
+                if (NULL == val || PMIX_INFO_ARRAY != PMIX_GET_TYPE(val->type)) {
                     /* this is an error */
                     PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
                     cb->value_cbfunc(PMIX_ERR_BAD_PARAM, NULL, cb->cbdata);
@@ -446,7 +446,7 @@ static void _getnbfn(int fd, short flags, void *cbdata)
             /* since we didn't provide them with a key, the hash function
              * must return the results in the pmix_info_array field of the
              * value */
-            if (NULL == val || PMIX_INFO_ARRAY != val->type) {
+            if (NULL == val || PMIX_INFO_ARRAY != PMIX_GET_TYPE(val->type)) {
                 /* this is an error */
                 PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
                 cb->value_cbfunc(PMIX_ERR_BAD_PARAM, NULL, cb->cbdata);

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -531,7 +531,7 @@ static void _register_nspace(int sd, short args, void *cbdata)
             }
         } else if (0 == strcmp(cd->info[i].key, PMIX_PROC_DATA)) {
             /* an array of data pertaining to a specific proc */
-            if (PMIX_INFO_ARRAY != cd->info[i].value.type) {
+            if (PMIX_INFO_ARRAY != PMIX_GET_TYPE(cd->info[i].value.type)) {
                 PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
                 goto release;
             }


### PR DESCRIPTION
Take 24-bits from the pmix_data_type_t definition for bit-flags to indicate different behaviors for pmix_info_t, leaving 8-bits for integer values of data types. This limits us to 256 data types, but that should be sufficient.

Because we have to deal with endianness, provide macros for setting and getting the data type when flags may be present. Ditto for setting and getting of flags