### PR TITLE
Put the barrier at the end of the pmix_client.c test.

### DIFF
--- a/test/pmix_client.c
+++ b/test/pmix_client.c
@@ -190,6 +190,12 @@ int main(int argc, char **argv)
 
     TEST_VERBOSE(("Client ns %s rank %d: PASSED", myproc.nspace, myproc.rank));
     PMIx_Deregister_errhandler(1, op_callbk, NULL);
+
+    /* In case of direct modex we want to delay Finalize
+       until everybody has finished. Otherwise some processes
+       will fail to get data from others who already exited */
+    PMIx_Fence(NULL, 0, NULL, 0);
+
     /* finalize us */
     TEST_VERBOSE(("Client ns %s rank %d: Finalizing", myproc.nspace, myproc.rank));
     if (PMIX_SUCCESS != (rc = PMIx_Finalize())) {


### PR DESCRIPTION
We need this in case we test direct modex: if some process will
exit before others will request it's blob we will get an error.

Application developer is responsible for keeping all processes
running until all the data is retrieved from it. Here we achieve
this using PMIx_Fence.