### PR TITLE
Pr/issue 26

### DIFF
--- a/config/pmix_check_visibility.m4
+++ b/config/pmix_check_visibility.m4
@@ -30,7 +30,7 @@ AC_DEFUN([PMIX_CHECK_VISIBILITY],[
         AC_HELP_STRING([--enable-visibility],
             [enable visibility feature of certain compilers/linkers (default: enabled)]))
 
-    pmix_visibility_define=0
+    WANT_VISIBILITY=0
     pmix_msg="whether to enable symbol visibility"
 
     if test "$enable_visibility" = "no"; then
@@ -73,7 +73,8 @@ AC_DEFUN([PMIX_CHECK_VISIBILITY],[
         PMIX_VISIBILITY_CFLAGS=$pmix_add
 
         if test "$pmix_add" != "" ; then
-            pmix_visibility_define=1
+            WANT_VISIBILITY=1
+            CFLAGS="$CFLAGS $PMIX_VISIBILITY_CFLAGS"
             AC_MSG_CHECKING([$pmix_msg])
             AC_MSG_RESULT([yes (via $pmix_add)])
         elif test "$enable_visibility" = "yes"; then
@@ -85,6 +86,7 @@ AC_DEFUN([PMIX_CHECK_VISIBILITY],[
         unset pmix_add
     fi
 
-    AC_DEFINE_UNQUOTED([PMIX_C_HAVE_VISIBILITY], [$pmix_visibility_define],
+    AC_DEFINE_UNQUOTED([PMIX_C_HAVE_VISIBILITY], [$WANT_VISIBILITY],
             [Whether C compiler supports symbol visibility or not])
+    AM_CONDITIONAL([WANT_HIDDEN],[test "$WANT_VISIBILITY" = "1"])
 ])

--- a/contrib/pmix_jenkins.sh
+++ b/contrib/pmix_jenkins.sh
@@ -204,7 +204,7 @@ if [ "$jenkins_test_build" = "yes" ]; then
         autogen_script=./autogen.pl
     fi
 
-    configure_args=--with-libevent=$libevent_dir
+    configure_args="--with-libevent=$libevent_dir"
 
     # build pmix
     $autogen_script 
@@ -313,9 +313,13 @@ if [ -n "$JENKINS_RUN_TESTS" -a "$JENKINS_RUN_TESTS" -ne "0" ]; then
     echo "Checking for tests ..."
     
     run_tap=$WORKSPACE/run_test.tap
-    make $make_opt || exit 12
-
     rm -rf $run_tap
+
+    # build pmix
+    $autogen_script
+    echo ./configure --prefix=$pmix_dir $configure_args --disable-visibility | bash -xeE
+    make $make_opt install
+
     cd $WORKSPACE/test
 
     echo "1..11" > $run_tap

--- a/include/pmix/autogen/config.h.in
+++ b/include/pmix/autogen/config.h.in
@@ -147,14 +147,15 @@
 #endif
 
 #ifndef PMIX_DECLSPEC
+# define PMIX_DECLSPEC
 #ifdef PMIX_C_HAVE_VISIBILITY
 # if PMIX_C_HAVE_VISIBILITY
-#  define PMIX_DECLSPEC __attribute__((__visibility__("default")))
+#  define PMIX_EXPORT __attribute__((__visibility__("default")))
 # else
-#  define PMIX_DECLSPEC
+#  define PMIX_EXPORT
 # endif
 #else
-# define PMIX_DECLSPEC
+# define PMIX_EXPORT
 #endif
 #endif
 

--- a/include/pmix/autogen/pmix_config_bottom.h
+++ b/include/pmix/autogen/pmix_config_bottom.h
@@ -208,10 +208,8 @@
 #ifndef PMIX_DECLSPEC
 #  if PMIX_C_HAVE_VISIBILITY
 #    define PMIX_DECLSPEC           __pmix_attribute_visibility__("default")
-#    define PMIX_MODULE_DECLSPEC    __pmix_attribute_visibility__("default")
 #  else
 #    define PMIX_DECLSPEC
-#    define PMIX_MODULE_DECLSPEC
 #  endif
 #endif
 

--- a/include/pmix/autogen/pmix_config_bottom.h
+++ b/include/pmix/autogen/pmix_config_bottom.h
@@ -206,10 +206,11 @@
 #endif
 
 #ifndef PMIX_DECLSPEC
+#define PMIX_DECLSPEC
 #  if PMIX_C_HAVE_VISIBILITY
-#    define PMIX_DECLSPEC           __pmix_attribute_visibility__("default")
+#    define PMIX_EXPORT           __pmix_attribute_visibility__("default")
 #  else
-#    define PMIX_DECLSPEC
+#    define PMIX_EXPORT
 #  endif
 #endif
 

--- a/include/pmix/pmix_common.h
+++ b/include/pmix/pmix_common.h
@@ -495,8 +495,7 @@ typedef struct {
  * includes internal functions - so we don't
  * want to expose the entire header here
  */
-extern void pmix_value_load(pmix_value_t *v, void *data,
-                            pmix_data_type_t type);
+void pmix_value_load(pmix_value_t *v, void *data, pmix_data_type_t type);
 
 
 
@@ -918,8 +917,8 @@ const char* PMIx_Get_version(void);
 /* Store some data locally for retrieval by other areas of the
  * proc. This is data that has only internal scope - it will
  * never be "pushed" externally */
- pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc,
-                                   const char *key, pmix_value_t *val);
+pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc,
+                                  const char *key, pmix_value_t *val);
 
 
 /* Key-Value pair management macros */

--- a/src/buffer_ops/open_close.c
+++ b/src/buffer_ops/open_close.c
@@ -392,8 +392,8 @@ pmix_status_t pmix_bfrop_close(void)
 }
 
 /**** UTILITY SUPPORT ****/
-void pmix_value_load(pmix_value_t *v, void *data,
-                     pmix_data_type_t type)
+PMIX_EXPORT void pmix_value_load(pmix_value_t *v, void *data,
+                                 pmix_data_type_t type)
 {
     pmix_byte_object_t *bo;
 

--- a/src/client/pmi1.c
+++ b/src/client/pmi1.c
@@ -58,7 +58,7 @@ static int convert_err(pmix_status_t rc);
 static pmix_proc_t myproc;
 static int pmi_init = 0;
 
-int PMI_Init(int *spawned)
+PMIX_EXPORT int PMI_Init(int *spawned)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_value_t *val;
@@ -103,7 +103,7 @@ error:
     return convert_err(rc);
 }
 
-int PMI_Initialized(PMI_BOOL *initialized)
+PMIX_EXPORT int PMI_Initialized(PMI_BOOL *initialized)
 {
     if (NULL == initialized) {
         return PMI_ERR_INVALID_ARG;
@@ -114,7 +114,7 @@ int PMI_Initialized(PMI_BOOL *initialized)
     return PMI_SUCCESS;
 }
 
-int PMI_Finalize(void)
+PMIX_EXPORT int PMI_Finalize(void)
 {
     pmix_status_t rc = PMIX_SUCCESS;
 
@@ -125,7 +125,7 @@ int PMI_Finalize(void)
     return convert_err(rc);
 }
 
-int PMI_Abort(int flag, const char msg[])
+PMIX_EXPORT int PMI_Abort(int flag, const char msg[])
 {
     pmix_status_t rc = PMIX_SUCCESS;
 
@@ -137,7 +137,7 @@ int PMI_Abort(int flag, const char msg[])
 
 /* KVS_Put - we default to PMIX_GLOBAL scope and ignore the
  * provided kvsname as we only put into our own nspace */
-int PMI_KVS_Put(const char kvsname[], const char key[], const char value[])
+PMIX_EXPORT int PMI_KVS_Put(const char kvsname[], const char key[], const char value[])
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_value_t val;
@@ -164,7 +164,7 @@ int PMI_KVS_Put(const char kvsname[], const char key[], const char value[])
 }
 
 /* KVS_Commit */
-int PMI_KVS_Commit(const char kvsname[])
+PMIX_EXPORT int PMI_KVS_Commit(const char kvsname[])
 {
     pmix_status_t rc = PMIX_SUCCESS;
 
@@ -181,7 +181,7 @@ int PMI_KVS_Commit(const char kvsname[])
     return convert_err(rc);
 }
 
-int PMI_KVS_Get( const char kvsname[], const char key[], char value[], int length)
+PMIX_EXPORT int PMI_KVS_Get( const char kvsname[], const char key[], char value[], int length)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_value_t *val;
@@ -222,7 +222,7 @@ int PMI_KVS_Get( const char kvsname[], const char key[], char value[], int lengt
 
 /* Barrier only applies to our own nspace, and we want all
  * data to be collected upon completion */
-int PMI_Barrier(void)
+PMIX_EXPORT int PMI_Barrier(void)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_info_t buf;
@@ -243,7 +243,7 @@ int PMI_Barrier(void)
     return convert_err(rc);
 }
 
-int PMI_Get_size(int *size)
+PMIX_EXPORT int PMI_Get_size(int *size)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_value_t *val;
@@ -276,7 +276,7 @@ int PMI_Get_size(int *size)
     return convert_err(rc);
 }
 
-int PMI_Get_rank(int *rk)
+PMIX_EXPORT int PMI_Get_rank(int *rk)
 {
     PMI_CHECK();
 
@@ -288,7 +288,7 @@ int PMI_Get_rank(int *rk)
     return PMI_SUCCESS;
 }
 
-int PMI_Get_universe_size(int *size)
+PMIX_EXPORT int PMI_Get_universe_size(int *size)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_value_t *val;
@@ -321,7 +321,7 @@ int PMI_Get_universe_size(int *size)
     return convert_err(rc);
 }
 
-int PMI_Get_appnum(int *appnum)
+PMIX_EXPORT int PMI_Get_appnum(int *appnum)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_value_t *val;
@@ -354,7 +354,7 @@ int PMI_Get_appnum(int *appnum)
     return convert_err(rc);
 }
 
-int PMI_Publish_name(const char service_name[], const char port[])
+PMIX_EXPORT int PMI_Publish_name(const char service_name[], const char port[])
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_info_t info;
@@ -377,7 +377,7 @@ int PMI_Publish_name(const char service_name[], const char port[])
     return convert_err(rc);
 }
 
-int PMI_Unpublish_name(const char service_name[])
+PMIX_EXPORT int PMI_Unpublish_name(const char service_name[])
 {
     pmix_status_t rc = PMIX_SUCCESS;
     char *keys[2];
@@ -396,7 +396,7 @@ int PMI_Unpublish_name(const char service_name[])
     return convert_err(rc);
 }
 
-int PMI_Lookup_name(const char service_name[], char port[])
+PMIX_EXPORT int PMI_Lookup_name(const char service_name[], char port[])
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_pdata_t pdata;
@@ -433,7 +433,7 @@ int PMI_Lookup_name(const char service_name[], char port[])
     return PMIX_SUCCESS;
 }
 
-int PMI_Get_id(char id_str[], int length)
+PMIX_EXPORT int PMI_Get_id(char id_str[], int length)
 {
     /* we already obtained our nspace during PMI_Init,
      * so all we have to do here is return it */
@@ -452,7 +452,7 @@ int PMI_Get_id(char id_str[], int length)
     return PMI_SUCCESS;
 }
 
-int PMI_Get_kvs_domain_id(char id_str[], int length)
+PMIX_EXPORT int PMI_Get_kvs_domain_id(char id_str[], int length)
 {
     PMI_CHECK();
 
@@ -460,7 +460,7 @@ int PMI_Get_kvs_domain_id(char id_str[], int length)
     return PMI_Get_id(id_str, length);
 }
 
-int PMI_Get_id_length_max(int *length)
+PMIX_EXPORT int PMI_Get_id_length_max(int *length)
 {
     PMI_CHECK();
 
@@ -472,7 +472,7 @@ int PMI_Get_id_length_max(int *length)
     return PMI_SUCCESS;
 }
 
-int PMI_Get_clique_size(int *size)
+PMIX_EXPORT int PMI_Get_clique_size(int *size)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_value_t *val;
@@ -501,7 +501,7 @@ int PMI_Get_clique_size(int *size)
     return convert_err(rc);
 }
 
-int PMI_Get_clique_ranks(int ranks[], int length)
+PMIX_EXPORT int PMI_Get_clique_ranks(int ranks[], int length)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_value_t *val;
@@ -528,7 +528,7 @@ int PMI_Get_clique_ranks(int ranks[], int length)
     return convert_err(rc);
 }
 
-int PMI_KVS_Get_my_name(char kvsname[], int length)
+PMIX_EXPORT int PMI_KVS_Get_my_name(char kvsname[], int length)
 {
     PMI_CHECK();
 
@@ -536,7 +536,7 @@ int PMI_KVS_Get_my_name(char kvsname[], int length)
     return PMI_Get_id(kvsname, length);
 }
 
-int PMI_KVS_Get_name_length_max(int *length)
+PMIX_EXPORT int PMI_KVS_Get_name_length_max(int *length)
 {
     PMI_CHECK();
 
@@ -548,7 +548,7 @@ int PMI_KVS_Get_name_length_max(int *length)
     return PMI_SUCCESS;
 }
 
-int PMI_KVS_Get_key_length_max(int *length)
+PMIX_EXPORT int PMI_KVS_Get_key_length_max(int *length)
 {
     PMI_CHECK();
 
@@ -560,7 +560,7 @@ int PMI_KVS_Get_key_length_max(int *length)
     return PMI_SUCCESS;
 }
 
-int PMI_KVS_Get_value_length_max(int *length)
+PMIX_EXPORT int PMI_KVS_Get_value_length_max(int *length)
 {
     PMI_CHECK();
 
@@ -576,33 +576,33 @@ int PMI_KVS_Get_value_length_max(int *length)
 
 /* nobody supports this call, which is why it was
  * dropped for PMI-2 */
-int PMI_KVS_Create(char kvsname[], int length)
+PMIX_EXPORT int PMI_KVS_Create(char kvsname[], int length)
 {
     return PMI_FAIL;
 }
 
 /* nobody supports this call, which is why it was
  * dropped for PMI-2 */
-int PMI_KVS_Destroy(const char kvsname[])
+PMIX_EXPORT int PMI_KVS_Destroy(const char kvsname[])
 {
     return PMI_FAIL;
 }
 
 /* nobody supports this call, which is why it was
  * dropped for PMI-2 */
-int PMI_KVS_Iter_first(const char kvsname[], char key[], int key_len, char val[], int val_len)
+PMIX_EXPORT int PMI_KVS_Iter_first(const char kvsname[], char key[], int key_len, char val[], int val_len)
 {
     return PMI_FAIL;
 }
 
 /* nobody supports this call, which is why it was
  * dropped for PMI-2 */
-int PMI_KVS_Iter_next(const char kvsname[], char key[], int key_len, char val[], int val_len)
+PMIX_EXPORT int PMI_KVS_Iter_next(const char kvsname[], char key[], int key_len, char val[], int val_len)
 {
     return PMI_FAIL;
 }
 
-int PMI_Spawn_multiple(int count,
+PMIX_EXPORT int PMI_Spawn_multiple(int count,
                        const char * cmds[],
                        const char ** argvs[],
                        const int maxprocs[],
@@ -665,28 +665,28 @@ int PMI_Spawn_multiple(int count,
 
 /* nobody supports this call, which is why it was
  * dropped for PMI-2 */
-int PMI_Parse_option(int num_args, char *args[], int *num_parsed, PMI_keyval_t **keyvalp, int *size)
+PMIX_EXPORT int PMI_Parse_option(int num_args, char *args[], int *num_parsed, PMI_keyval_t **keyvalp, int *size)
 {
     return PMI_FAIL;
 }
 
 /* nobody supports this call, which is why it was
  * dropped for PMI-2 */
-int PMI_Args_to_keyval(int *argcp, char *((*argvp)[]), PMI_keyval_t **keyvalp, int *size)
+PMIX_EXPORT int PMI_Args_to_keyval(int *argcp, char *((*argvp)[]), PMI_keyval_t **keyvalp, int *size)
 {
     return PMI_FAIL;
 }
 
 /* nobody supports this call, which is why it was
  * dropped for PMI-2 */
-int PMI_Free_keyvals(PMI_keyval_t keyvalp[], int size)
+PMIX_EXPORT int PMI_Free_keyvals(PMI_keyval_t keyvalp[], int size)
 {
     return PMI_FAIL;
 }
 
 /* nobody supports this call, which is why it was
  * dropped for PMI-2 */
-int PMI_Get_options(char *str, int *length)
+PMIX_EXPORT int PMI_Get_options(char *str, int *length)
 {
     return PMI_FAIL;
 }

--- a/src/client/pmi2.c
+++ b/src/client/pmi2.c
@@ -51,7 +51,7 @@ static pmix_proc_t myproc;
 static int pmi2_init = 0;
 static bool commit_reqd = false;
 
-int PMI2_Init(int *spawned, int *size, int *rank, int *appnum)
+PMIX_EXPORT int PMI2_Init(int *spawned, int *size, int *rank, int *appnum)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_value_t *val;
@@ -131,14 +131,14 @@ error:
     return convert_err(rc);
 }
 
-int PMI2_Initialized(void)
+PMIX_EXPORT int PMI2_Initialized(void)
 {
     int initialized;
     initialized = (int)PMIx_Initialized();
     return initialized;
 }
 
-int PMI2_Finalize(void)
+PMIX_EXPORT int PMI2_Finalize(void)
 {
     pmix_status_t rc = PMIX_SUCCESS;
 
@@ -149,7 +149,7 @@ int PMI2_Finalize(void)
     return convert_err(rc);
 }
 
-int PMI2_Abort(int flag, const char msg[])
+PMIX_EXPORT int PMI2_Abort(int flag, const char msg[])
 {
     pmix_status_t rc = PMIX_SUCCESS;
 
@@ -159,7 +159,7 @@ int PMI2_Abort(int flag, const char msg[])
     return convert_err(rc);
 }
 
-int PMI2_Job_Spawn(int count, const char * cmds[],
+PMIX_EXPORT int PMI2_Job_Spawn(int count, const char * cmds[],
                    int argcs[], const char ** argvs[],
                    const int maxprocs[],
                    const int info_keyval_sizes[],
@@ -219,7 +219,7 @@ int PMI2_Job_Spawn(int count, const char * cmds[],
     return convert_err(rc);
 }
 
-int PMI2_Job_GetId(char jobid[], int jobid_size)
+PMIX_EXPORT int PMI2_Job_GetId(char jobid[], int jobid_size)
 {
     /* we already obtained our nspace during pmi2_init,
      * so all we have to do here is return it */
@@ -234,7 +234,7 @@ int PMI2_Job_GetId(char jobid[], int jobid_size)
     return PMI2_SUCCESS;
 }
 
-int PMI2_Job_GetRank(int *rank)
+PMIX_EXPORT int PMI2_Job_GetRank(int *rank)
 {
     PMI2_CHECK();
 
@@ -245,7 +245,7 @@ int PMI2_Job_GetRank(int *rank)
     return PMI2_SUCCESS;
 }
 
-int PMI2_Info_GetSize(int *size)
+PMIX_EXPORT int PMI2_Info_GetSize(int *size)
 {
     pmix_status_t rc = PMIX_ERROR;
     pmix_value_t *val;
@@ -274,7 +274,7 @@ int PMI2_Info_GetSize(int *size)
     return convert_err(rc);
 }
 
-int PMI2_Job_Connect(const char jobid[], PMI2_Connect_comm_t *conn)
+PMIX_EXPORT int PMI2_Job_Connect(const char jobid[], PMI2_Connect_comm_t *conn)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_proc_t proc;
@@ -291,7 +291,7 @@ int PMI2_Job_Connect(const char jobid[], PMI2_Connect_comm_t *conn)
     return convert_err(rc);
 }
 
-int PMI2_Job_Disconnect(const char jobid[])
+PMIX_EXPORT int PMI2_Job_Disconnect(const char jobid[])
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_proc_t proc;
@@ -305,7 +305,7 @@ int PMI2_Job_Disconnect(const char jobid[])
 }
 
 /* KVS_Put - we default to PMIX_GLOBAL scope */
-int PMI2_KVS_Put(const char key[], const char value[])
+PMIX_EXPORT int PMI2_KVS_Put(const char key[], const char value[])
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_value_t val;
@@ -328,7 +328,7 @@ int PMI2_KVS_Put(const char key[], const char value[])
 }
 
 /* KVS_Fence */
-int PMI2_KVS_Fence(void)
+PMIX_EXPORT int PMI2_KVS_Fence(void)
 {
     pmix_status_t rc = PMIX_SUCCESS;
 
@@ -364,9 +364,9 @@ int PMI2_KVS_Fence(void)
  * will use the local nspace, which matches the PMI2 spec.
  * The only type of value supported by PMI2 is a string, so
  * the return of anything else is an error */
-int PMI2_KVS_Get(const char *jobid, int src_pmi_id,
-                 const char key[], char value [],
-                 int maxvalue, int *vallen)
+PMIX_EXPORT int PMI2_KVS_Get(const char *jobid, int src_pmi_id,
+                             const char key[], char value [],
+                             int maxvalue, int *vallen)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_value_t *val;
@@ -410,7 +410,9 @@ int PMI2_KVS_Get(const char *jobid, int src_pmi_id,
     return convert_err(rc);
 }
 
-int PMI2_Info_GetNodeAttr(const char name[], char value[], int valuelen, int *found, int waitfor)
+PMIX_EXPORT int PMI2_Info_GetNodeAttr(const char name[],
+                                      char value[], int valuelen,
+                                      int *found, int waitfor)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_value_t *val;
@@ -448,14 +450,14 @@ int PMI2_Info_GetNodeAttr(const char name[], char value[], int valuelen, int *fo
     return convert_err(rc);
 }
 
-int PMI2_Info_GetNodeAttrIntArray(const char name[], int array[],
+PMIX_EXPORT int PMI2_Info_GetNodeAttrIntArray(const char name[], int array[],
                                   int arraylen, int *outlen, int *found)
 {
     return PMI2_FAIL;
 }
 
 /* push info at the PMIX_LOCAL scope */
-int PMI2_Info_PutNodeAttr(const char name[], const char value[])
+PMIX_EXPORT int PMI2_Info_PutNodeAttr(const char name[], const char value[])
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_value_t val;
@@ -472,7 +474,7 @@ int PMI2_Info_PutNodeAttr(const char name[], const char value[])
     return convert_err(rc);
 }
 
-int PMI2_Info_GetJobAttr(const char name[], char value[], int valuelen, int *found)
+PMIX_EXPORT int PMI2_Info_GetJobAttr(const char name[], char value[], int valuelen, int *found)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_value_t *val;
@@ -515,12 +517,15 @@ int PMI2_Info_GetJobAttr(const char name[], char value[], int valuelen, int *fou
     return convert_err(rc);
 }
 
-int PMI2_Info_GetJobAttrIntArray(const char name[], int array[], int arraylen, int *outlen, int *found)
+PMIX_EXPORT int PMI2_Info_GetJobAttrIntArray(const char name[],
+                                             int array[], int arraylen,
+                                             int *outlen, int *found)
 {
     return PMI2_FAIL;
 }
 
-int PMI2_Nameserv_publish(const char service_name[], const PMI_keyval_t *info_ptr, const char port[])
+PMIX_EXPORT int PMI2_Nameserv_publish(const char service_name[],
+                                      const PMI_keyval_t *info_ptr, const char port[])
 {
     pmix_status_t rc = PMIX_SUCCESS;
     int nvals;
@@ -552,8 +557,9 @@ int PMI2_Nameserv_publish(const char service_name[], const PMI_keyval_t *info_pt
     return convert_err(rc);
 }
 
-int PMI2_Nameserv_lookup(const char service_name[], const PMI_keyval_t *info_ptr,
-                         char port[], int portLen)
+PMIX_EXPORT int PMI2_Nameserv_lookup(const char service_name[],
+                                     const PMI_keyval_t *info_ptr,
+                                     char port[], int portLen)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     int nvals;
@@ -606,7 +612,7 @@ int PMI2_Nameserv_lookup(const char service_name[], const PMI_keyval_t *info_ptr
     return PMI2_SUCCESS;
 }
 
-int PMI2_Nameserv_unpublish(const char service_name[],
+PMIX_EXPORT int PMI2_Nameserv_unpublish(const char service_name[],
                            const PMI_keyval_t *info_ptr)
 {
     pmix_status_t rc = PMIX_SUCCESS;

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -234,12 +234,12 @@ static pmix_status_t connect_to_server(struct sockaddr_un *address, void *cbdata
     return PMIX_SUCCESS;
 }
 
-const char* PMIx_Get_version(void)
+PMIX_EXPORT const char* PMIx_Get_version(void)
 {
     return pmix_version_string;
 }
 
-int PMIx_Init(pmix_proc_t *proc)
+PMIX_EXPORT int PMIx_Init(pmix_proc_t *proc)
 {
     char **uri, *evar;
     int rc, debug_level;
@@ -410,7 +410,7 @@ int PMIx_Init(pmix_proc_t *proc)
     return rc;
 }
 
-int PMIx_Initialized(void)
+PMIX_EXPORT int PMIx_Initialized(void)
 {
     if (0 < pmix_globals.init_cntr) {
         return true;
@@ -418,7 +418,7 @@ int PMIx_Initialized(void)
     return false;
 }
 
-pmix_status_t PMIx_Finalize(void)
+PMIX_EXPORT pmix_status_t PMIx_Finalize(void)
 {
     pmix_buffer_t *msg;
     pmix_cb_t *cb;
@@ -492,7 +492,7 @@ pmix_status_t PMIx_Finalize(void)
     return PMIX_SUCCESS;
 }
 
-int PMIx_Abort(int flag, const char msg[],
+PMIX_EXPORT int PMIx_Abort(int flag, const char msg[],
                pmix_proc_t procs[], size_t nprocs)
 {
     pmix_buffer_t *bfr;
@@ -633,7 +633,7 @@ static void _putfn(int sd, short args, void *cbdata)
     cb->active = false;
 }
 
-pmix_status_t PMIx_Put(pmix_scope_t scope, const char key[], pmix_value_t *val)
+PMIX_EXPORT pmix_status_t PMIx_Put(pmix_scope_t scope, const char key[], pmix_value_t *val)
 {
     pmix_cb_t *cb;
     pmix_status_t rc;
@@ -720,7 +720,7 @@ static void _commitfn(int sd, short args, void *cbdata)
     cb->active = false;
 }
 
-pmix_status_t PMIx_Commit(void)
+PMIX_EXPORT pmix_status_t PMIx_Commit(void)
 {
     pmix_cb_t *cb;
     pmix_status_t rc;
@@ -800,8 +800,9 @@ static void _peersfn(int sd, short args, void *cbdata)
     cb->active = false;
 }
 
-pmix_status_t PMIx_Resolve_peers(const char *nodename, const char *nspace,
-                                 pmix_proc_t **procs, size_t *nprocs)
+PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename,
+                                             const char *nspace,
+                                             pmix_proc_t **procs, size_t *nprocs)
 {
     pmix_cb_t *cb;
     pmix_status_t rc;
@@ -860,7 +861,7 @@ static void _nodesfn(int sd, short args, void *cbdata)
     cb->active = false;
 }
 
-pmix_status_t PMIx_Resolve_nodes(const char *nspace, char **nodelist)
+PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const char *nspace, char **nodelist)
 {
     pmix_cb_t *cb;
     pmix_status_t rc;

--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -58,8 +58,8 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
                         pmix_buffer_t *buf, void *cbdata);
 static void op_cbfunc(int status, void *cbdata);
 
-int PMIx_Connect(const pmix_proc_t procs[], size_t nprocs,
-                 const pmix_info_t info[], size_t ninfo)
+PMIX_EXPORT int PMIx_Connect(const pmix_proc_t procs[], size_t nprocs,
+                             const pmix_info_t info[], size_t ninfo)
 {
     int rc;
     pmix_cb_t *cb;
@@ -99,9 +99,9 @@ int PMIx_Connect(const pmix_proc_t procs[], size_t nprocs,
     return rc;
 }
 
-pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t nprocs,
-                              const pmix_info_t info[], size_t ninfo,
-                              pmix_op_cbfunc_t cbfunc, void *cbdata)
+PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t nprocs,
+                                          const pmix_info_t info[], size_t ninfo,
+                                          pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_buffer_t *msg;
     pmix_cmd_t cmd = PMIX_CONNECTNB_CMD;
@@ -169,8 +169,8 @@ pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t nprocs,
     return PMIX_SUCCESS;
 }
 
-int PMIx_Disconnect(const pmix_proc_t procs[], size_t nprocs,
-                    const pmix_info_t info[], size_t ninfo)
+PMIX_EXPORT int PMIx_Disconnect(const pmix_proc_t procs[], size_t nprocs,
+                                const pmix_info_t info[], size_t ninfo)
 {
     int rc;
     pmix_cb_t *cb;
@@ -206,9 +206,9 @@ int PMIx_Disconnect(const pmix_proc_t procs[], size_t nprocs,
     return rc;
 }
 
-pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t procs[], size_t nprocs,
-                                 const pmix_info_t info[], size_t ninfo,
-                                 pmix_op_cbfunc_t cbfunc, void *cbdata)
+PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t procs[], size_t nprocs,
+                                             const pmix_info_t info[], size_t ninfo,
+                                             pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_buffer_t *msg;
     pmix_cmd_t cmd = PMIX_DISCONNECTNB_CMD;

--- a/src/client/pmix_client_fence.c
+++ b/src/client/pmix_client_fence.c
@@ -65,8 +65,8 @@ static void wait_cbfunc(struct pmix_peer_t *pr,
                         pmix_buffer_t *buf, void *cbdata);
 static void op_cbfunc(int status, void *cbdata);
 
-int PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
-               const pmix_info_t info[], size_t ninfo)
+PMIX_EXPORT int PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
+                           const pmix_info_t info[], size_t ninfo)
 {
     pmix_cb_t *cb;
     int rc;
@@ -107,9 +107,9 @@ int PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
     return rc;
 }
 
-int PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs,
-                  const pmix_info_t info[], size_t ninfo,
-                  pmix_op_cbfunc_t cbfunc, void *cbdata)
+PMIX_EXPORT int PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs,
+                              const pmix_info_t info[], size_t ninfo,
+                              pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_buffer_t *msg;
     pmix_cmd_t cmd = PMIX_FENCENB_CMD;

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -70,9 +70,9 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
 
 static void _value_cbfunc(int status, pmix_value_t *kv, void *cbdata);
 
-int PMIx_Get(const pmix_proc_t *proc, const char key[],
-             const pmix_info_t info[], size_t ninfo,
-             pmix_value_t **val)
+PMIX_EXPORT int PMIx_Get(const pmix_proc_t *proc, const char key[],
+                         const pmix_info_t info[], size_t ninfo,
+                         pmix_value_t **val)
 {
     pmix_cb_t *cb;
     int rc;
@@ -103,9 +103,9 @@ int PMIx_Get(const pmix_proc_t *proc, const char key[],
     return rc;
 }
 
-pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char *key,
-                          const pmix_info_t info[], size_t ninfo,
-                          pmix_value_cbfunc_t cbfunc, void *cbdata)
+PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char *key,
+                                      const pmix_info_t info[], size_t ninfo,
+                                      pmix_value_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_cb_t *cb;
     int rank;

--- a/src/client/pmix_client_pub.c
+++ b/src/client/pmix_client_pub.c
@@ -61,8 +61,8 @@ static void wait_lookup_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
 static void lookup_cbfunc(int status, pmix_pdata_t pdata[], size_t ndata,
                           void *cbdata);
 
-pmix_status_t PMIx_Publish(const pmix_info_t info[],
-                           size_t ninfo)
+PMIX_EXPORT pmix_status_t PMIx_Publish(const pmix_info_t info[],
+                                       size_t ninfo)
 {
     pmix_status_t rc;
     pmix_cb_t *cb;
@@ -97,8 +97,8 @@ pmix_status_t PMIx_Publish(const pmix_info_t info[],
     return rc;
 }
 
-pmix_status_t PMIx_Publish_nb(const pmix_info_t info[], size_t ninfo,
-                              pmix_op_cbfunc_t cbfunc, void *cbdata)
+PMIX_EXPORT pmix_status_t PMIx_Publish_nb(const pmix_info_t info[], size_t ninfo,
+                                          pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_buffer_t *msg;
     pmix_cmd_t cmd = PMIX_PUBLISHNB_CMD;
@@ -166,8 +166,8 @@ pmix_status_t PMIx_Publish_nb(const pmix_info_t info[], size_t ninfo,
     return PMIX_SUCCESS;
 }
 
-int PMIx_Lookup(pmix_pdata_t pdata[], size_t ndata,
-                const pmix_info_t info[], size_t ninfo)
+PMIX_EXPORT int PMIx_Lookup(pmix_pdata_t pdata[], size_t ndata,
+                            const pmix_info_t info[], size_t ninfo)
 {
     int rc;
     pmix_cb_t *cb;
@@ -214,8 +214,9 @@ int PMIx_Lookup(pmix_pdata_t pdata[], size_t ndata,
     return rc;
 }
 
-pmix_status_t PMIx_Lookup_nb(char **keys, const pmix_info_t info[], size_t ninfo,
-                             pmix_lookup_cbfunc_t cbfunc, void *cbdata)
+PMIX_EXPORT pmix_status_t PMIx_Lookup_nb(char **keys,
+                                         const pmix_info_t info[], size_t ninfo,
+                                         pmix_lookup_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_buffer_t *msg;
     pmix_cmd_t cmd = PMIX_LOOKUPNB_CMD;
@@ -292,7 +293,8 @@ pmix_status_t PMIx_Lookup_nb(char **keys, const pmix_info_t info[], size_t ninfo
     return PMIX_SUCCESS;
 }
 
-int PMIx_Unpublish(char **keys, const pmix_info_t info[], size_t ninfo)
+PMIX_EXPORT int PMIx_Unpublish(char **keys,
+                               const pmix_info_t info[], size_t ninfo)
 {
     int rc;
     pmix_cb_t *cb;
@@ -320,8 +322,9 @@ int PMIx_Unpublish(char **keys, const pmix_info_t info[], size_t ninfo)
     return rc;
 }
 
-pmix_status_t PMIx_Unpublish_nb(char **keys, const pmix_info_t info[], size_t ninfo,
-                                pmix_op_cbfunc_t cbfunc, void *cbdata)
+PMIX_EXPORT pmix_status_t PMIx_Unpublish_nb(char **keys,
+                                            const pmix_info_t info[], size_t ninfo,
+                                            pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_buffer_t *msg;
     pmix_cmd_t cmd = PMIX_UNPUBLISHNB_CMD;

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -57,9 +57,9 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
                         pmix_buffer_t *buf, void *cbdata);
 static void spawn_cbfunc(int status, char nspace[], void *cbdata);
 
-int PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
-               const pmix_app_t apps[], size_t napps,
-               char nspace[])
+PMIX_EXPORT int PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
+                           const pmix_app_t apps[], size_t napps,
+                           char nspace[])
 {
     int rc;
     pmix_cb_t *cb;
@@ -101,9 +101,9 @@ int PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
     return rc;
 }
 
-pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t ninfo,
-                            const pmix_app_t apps[], size_t napps,
-                            pmix_spawn_cbfunc_t cbfunc, void *cbdata)
+PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t ninfo,
+                                        const pmix_app_t apps[], size_t napps,
+                                        pmix_spawn_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_buffer_t *msg;
     pmix_cmd_t cmd = PMIX_SPAWNNB_CMD;

--- a/src/common/pmix_common.c
+++ b/src/common/pmix_common.c
@@ -23,7 +23,7 @@
 #include "src/server/pmix_server_ops.h"
 #include "src/include/pmix_globals.h"
 
-void PMIx_Register_errhandler(pmix_info_t info[], size_t ninfo,
+PMIX_EXPORT void PMIx_Register_errhandler(pmix_info_t info[], size_t ninfo,
                               pmix_notification_fn_t errhandler,
                               pmix_errhandler_reg_cbfunc_t cbfunc,
                               void *cbdata)
@@ -50,7 +50,7 @@ void PMIx_Register_errhandler(pmix_info_t info[], size_t ninfo,
     }
 }
 
-void PMIx_Deregister_errhandler(int errhandler_ref,
+PMIX_EXPORT void PMIx_Deregister_errhandler(int errhandler_ref,
                                 pmix_op_cbfunc_t cbfunc,
                                 void *cbdata)
 {
@@ -71,7 +71,7 @@ void PMIx_Deregister_errhandler(int errhandler_ref,
     }
 }
 
-pmix_status_t PMIx_Notify_error(pmix_status_t status,
+PMIX_EXPORT pmix_status_t PMIx_Notify_error(pmix_status_t status,
                                 pmix_proc_t procs[], size_t nprocs,
                                 pmix_proc_t error_procs[], size_t error_nprocs,
                                 pmix_info_t info[], size_t ninfo,

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -288,8 +288,8 @@ static pmix_status_t initialize_server_base(pmix_server_module_t *module)
     return PMIX_SUCCESS;
 }
 
-pmix_status_t PMIx_server_init(pmix_server_module_t *module,
-                               pmix_info_t info[], size_t ninfo)
+PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
+                                           pmix_info_t info[], size_t ninfo)
 {
     pmix_usock_posted_recv_t *req;
     pmix_status_t rc;
@@ -416,7 +416,7 @@ static void cleanup_server_state(void)
     pmix_class_finalize();
 }
 
-pmix_status_t PMIx_server_finalize(void)
+PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
 {
     if (1 != pmix_globals.init_cntr) {
         --pmix_globals.init_cntr;
@@ -621,9 +621,9 @@ static void _register_nspace(int sd, short args, void *cbdata)
 }
 
 /* setup the data for a job */
-pmix_status_t PMIx_server_register_nspace(const char nspace[], int nlocalprocs,
-                                          pmix_info_t info[], size_t ninfo,
-                                          pmix_op_cbfunc_t cbfunc, void *cbdata)
+PMIX_EXPORT pmix_status_t PMIx_server_register_nspace(const char nspace[], int nlocalprocs,
+                                                      pmix_info_t info[], size_t ninfo,
+                                                      pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_setup_caddy_t *cd;
 
@@ -665,7 +665,7 @@ static void _deregister_nspace(int sd, short args, void *cbdata)
     PMIX_RELEASE(cd);
 }
 
-void PMIx_server_deregister_nspace(const char nspace[])
+PMIX_EXPORT void PMIx_server_deregister_nspace(const char nspace[])
 {
     pmix_setup_caddy_t *cd;
 
@@ -836,9 +836,9 @@ static void _register_client(int sd, short args, void *cbdata)
     PMIX_RELEASE(cd);
 }
 
-pmix_status_t PMIx_server_register_client(const pmix_proc_t *proc,
-                                          uid_t uid, gid_t gid, void *server_object,
-                                          pmix_op_cbfunc_t cbfunc, void *cbdata)
+PMIX_EXPORT pmix_status_t PMIx_server_register_client(const pmix_proc_t *proc,
+                                                      uid_t uid, gid_t gid, void *server_object,
+                                                      pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_setup_caddy_t *cd;
 
@@ -896,7 +896,7 @@ static void _deregister_client(int sd, short args, void *cbdata)
     PMIX_RELEASE(cd);
 }
 
-void PMIx_server_deregister_client(const pmix_proc_t *proc)
+PMIX_EXPORT void PMIx_server_deregister_client(const pmix_proc_t *proc)
 {
     pmix_setup_caddy_t *cd;
 
@@ -914,7 +914,7 @@ void PMIx_server_deregister_client(const pmix_proc_t *proc)
 }
 
 /* setup the envars for a child process */
-pmix_status_t PMIx_server_setup_fork(const pmix_proc_t *proc, char ***env)
+PMIX_EXPORT pmix_status_t PMIx_server_setup_fork(const pmix_proc_t *proc, char ***env)
 {
     char rankstr[128];
 
@@ -1032,9 +1032,9 @@ static void _dmodex_req(int sd, short args, void *cbdata)
     cd->active = false;
 }
 
-pmix_status_t PMIx_server_dmodex_request(const pmix_proc_t *proc,
-                                         pmix_dmodex_response_fn_t cbfunc,
-                                         void *cbdata)
+PMIX_EXPORT pmix_status_t PMIx_server_dmodex_request(const pmix_proc_t *proc,
+                                                     pmix_dmodex_response_fn_t cbfunc,
+                                                     void *cbdata)
 {
     pmix_setup_caddy_t *cd;
 
@@ -1360,8 +1360,8 @@ static void _store_internal(int sd, short args, void *cbdata)
     cd->active = false;
  }
 
-pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc,
-                                  const char *key, pmix_value_t *val)
+PMIX_EXPORT pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc,
+                                              const char *key, pmix_value_t *val)
 {
     pmix_shift_caddy_t *cd;
     pmix_status_t rc;
@@ -1395,7 +1395,7 @@ pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc,
 
 #define PMIX_MAX_NODE_PREFIX        50
 
-pmix_status_t PMIx_generate_regex(const char *input, char **regexp)
+PMIX_EXPORT pmix_status_t PMIx_generate_regex(const char *input, char **regexp)
 {
     char *vptr, *vsave;
     char prefix[PMIX_MAX_NODE_PREFIX];
@@ -1609,7 +1609,7 @@ pmix_status_t PMIx_generate_regex(const char *input, char **regexp)
     return PMIX_SUCCESS;
 }
 
-pmix_status_t PMIx_generate_ppn(const char *input, char **regexp)
+PMIX_EXPORT pmix_status_t PMIx_generate_ppn(const char *input, char **regexp)
 {
     char **ppn, **npn;
     int i, j, start, end;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -19,13 +19,20 @@
 # $HEADER$
 #
 
+if !WANT_HIDDEN
+# these tests use interanl symbols
+# use --disable-visibility
 SUBDIRS = simple
+endif
 
 headers = test_common.h cli_stages.h server_callbacks.h utils.h test_fence.h test_publish.h test_spawn.h test_cd.h test_resolve_peers.h test_error.h
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/src/api
 
-noinst_PROGRAMS = pmix_test pmix_client pmi_client pmi2_client pmix_regex
+noinst_PROGRAMS = pmi_client pmi2_client
+if !WANT_HIDDEN
+noinst_PROGRAMS += pmix_test pmix_client pmix_regex
+endif
 
 pmix_test_SOURCES = $(headers) \
         pmix_test.c test_common.c cli_stages.c server_callbacks.c utils.c


### PR DESCRIPTION
Fix https://github.com/pmix/master/issues/26

Note: some tests require pmix internals. But now only PMIx API are exported in default configure. So use --disable-visibility to get tests built.

@rhc54 please look at