### PR TITLE
Correct use of do/while loops to consume semicolon.

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -99,7 +99,7 @@ int main(int argc, char **argv)
     proc.rank = PMIX_RANK_WILDCARD;
     PMIX_INFO_CREATE(info, 1);
     flag = true;
-    PMIX_INFO_LOAD(info, PMIX_COLLECT_DATA, &flag, PMIX_BOOL)
+    PMIX_INFO_LOAD(info, PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
     if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, info, 1))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %d\n", myproc.nspace, myproc.rank, rc);
         goto done;

--- a/examples/dmodex.c
+++ b/examples/dmodex.c
@@ -43,7 +43,7 @@ static uint32_t getcount = 0;
         while ((a)) {                           \
             usleep(10);                         \
         }                                       \
-    } while (0);
+    } while (0)
 
 static void opcbfunc(pmix_status_t status, void *cbdata)
 {

--- a/include/pmix/pmix_common.h
+++ b/include/pmix/pmix_common.h
@@ -378,17 +378,17 @@ typedef struct {
     do {                                                        \
         (m) = (pmix_proc_t*)malloc((n) * sizeof(pmix_proc_t));  \
         memset((m), 0, (n) * sizeof(pmix_proc_t));              \
-    } while(0);
+    } while (0)
 
 #define PMIX_PROC_RELEASE(m)                    \
     do {                                        \
         PMIX_PROC_FREE((m));                    \
-    } while(0);
+    } while (0)
 
 #define PMIX_PROC_CONSTRUCT(m)                  \
     do {                                        \
         memset((m), 0, sizeof(pmix_proc_t));    \
-    } while(0);
+    } while (0)
 
 #define PMIX_PROC_DESTRUCT(m)
 
@@ -397,7 +397,7 @@ typedef struct {
         if (NULL != (m)) {                      \
             free((m));                          \
         }                                       \
-    } while(0);
+    } while (0)
 
 
 
@@ -449,21 +449,21 @@ typedef struct {
         for (_ii=0; _ii < (int)(n); _ii++) {                            \
             (m)[_ii].type = PMIX_UNDEF;                                 \
         }                                                               \
-    } while(0);
+    } while (0)
 
 /* release a single pmix_value_t struct, including its data */
 #define PMIX_VALUE_RELEASE(m)                                           \
     do {                                                                \
         PMIX_VALUE_DESTRUCT((m));                                       \
         free((m));                                                      \
-    } while(0);
+    } while (0)
 
 /* initialize a single value struct */
 #define PMIX_VALUE_CONSTRUCT(m)                 \
     do {                                        \
         memset((m), 0, sizeof(pmix_value_t));   \
         (m)->type = PMIX_UNDEF;                 \
-    } while(0);
+    } while (0)
 
 /* release the memory in the value struct data field */
 #define PMIX_VALUE_DESTRUCT(m)                                          \
@@ -492,7 +492,7 @@ typedef struct {
             }                                                           \
             free(_p);                                                   \
         }                                                               \
-    } while(0);
+    } while (0)
 
 #define PMIX_VALUE_FREE(m, n)                           \
     do {                                                \
@@ -503,7 +503,7 @@ typedef struct {
             }                                           \
             free((m));                                  \
         }                                               \
-    } while(0);
+    } while (0)
 
 /* expose a function that is resolved in the
  * PMIx library, but part of a header that
@@ -527,18 +527,18 @@ typedef struct {
     do {                                                        \
         (m) = (pmix_info_t*)malloc((n) * sizeof(pmix_info_t));  \
         memset((m), 0, (n) * sizeof(pmix_info_t));              \
-    } while(0);
+    } while (0)
 
 #define PMIX_INFO_CONSTRUCT(m)                  \
     do {                                        \
         memset((m), 0, sizeof(pmix_info_t));    \
         (m)->value.type = PMIX_UNDEF;           \
-    } while(0);
+    } while (0)
 
 #define PMIX_INFO_DESTRUCT(m) \
     do {                                        \
         PMIX_VALUE_DESTRUCT(&(m)->value);       \
-    } while(0);
+    } while (0)
 
 #define PMIX_INFO_FREE(m, n)                    \
     do {                                        \
@@ -549,13 +549,13 @@ typedef struct {
             }                                   \
             free((m));                          \
         }                                       \
-    } while(0);
+    } while (0)
 
 #define PMIX_INFO_LOAD(m, k, v, t)                      \
     do {                                                \
         (void)strncpy((m)->key, (k), PMIX_MAX_KEYLEN);  \
         pmix_value_load(&((m)->value), (v), (t));       \
-    } while(0);
+    } while (0)
 #define PMIX_INFO_REQUIRED(m)       \
     (m)->required = true;
 #define PMIX_INFO_OPTIONAL(m)       \
@@ -573,24 +573,24 @@ typedef struct {
     do {                                                                \
         (m) = (pmix_pdata_t*)malloc((n) * sizeof(pmix_pdata_t));        \
         memset((m), 0, (n) * sizeof(pmix_pdata_t));                     \
-    } while(0);
+    } while (0)
 
 #define PMIX_PDATA_RELEASE(m)                   \
     do {                                        \
         PMIX_VALUE_DESTRUCT(&(m)->value);       \
         free((m));                              \
-    } while(0);
+    } while (0)
 
 #define PMIX_PDATA_CONSTRUCT(m)                 \
     do {                                        \
         memset((m), 0, sizeof(pmix_pdata_t));   \
         (m)->value.type = PMIX_UNDEF;           \
-    } while(0);
+    } while (0)
 
 #define PMIX_PDATA_DESTRUCT(m)                  \
     do {                                        \
         PMIX_VALUE_DESTRUCT(&(m)->value);       \
-    } while(0);
+    } while (0)
 
 #define PMIX_PDATA_FREE(m, n)                           \
     do {                                                \
@@ -601,7 +601,7 @@ typedef struct {
             }                                           \
             free((m));                                  \
         }                                               \
-    } while(0);
+    } while (0)
 
 #define PMIX_PDATA_LOAD(m, p, k, v, t)                                  \
     do {                                                                \
@@ -610,7 +610,7 @@ typedef struct {
         (m)->proc.rank = (p)->rank;                                     \
         (void)strncpy((m)->key, (k), PMIX_MAX_KEYLEN);                  \
         pmix_value_load(&((m)->value), (v), (t));                       \
-    } while(0);
+    } while (0)
 
 
 /****    PMIX APP STRUCT    ****/
@@ -628,18 +628,18 @@ typedef struct {
     do {                                                        \
         (m) = (pmix_app_t*)malloc((n) * sizeof(pmix_app_t));    \
         memset((m), 0, (n) * sizeof(pmix_app_t));               \
-    } while(0);
+    } while (0)
 
 #define PMIX_APP_RELEASE(m)                     \
     do {                                        \
         PMIX_APP_DESTRUCT((m));                 \
         free((m));                              \
-    } while(0);
+    } while (0)
 
 #define PMIX_APP_CONSTRUCT(m)                   \
     do {                                        \
         memset((m), 0, sizeof(pmix_app_t));     \
-    } while(0);
+    } while (0)
 
 #define PMIX_APP_DESTRUCT(m)                                    \
     do {                                                        \
@@ -664,7 +664,7 @@ typedef struct {
                 PMIX_INFO_DESTRUCT(&(m)->info[_ii]);            \
             }                                                   \
         }                                                       \
-    } while(0);
+    } while (0)
 
 #define PMIX_APP_FREE(m, n)                     \
     do {                                        \
@@ -675,7 +675,7 @@ typedef struct {
             }                                   \
             free((m));                          \
         }                                       \
-    } while(0);
+    } while (0)
 
 /****    PMIX MODEX STRUCT    ****/
 typedef struct {
@@ -689,25 +689,25 @@ typedef struct {
     do {                                                                \
         (m) = (pmix_modex_data_t*)malloc((n) * sizeof(pmix_modex_data_t)); \
         memset((m), 0, (n) * sizeof(pmix_modex_data_t));                \
-    } while(0);
+    } while (0)
 
 #define PMIX_MODEX_RELEASE(m)                   \
     do {                                        \
         PMIX_MODEX_DESTRUCT((m));               \
         free((m));                              \
-    } while(0);
+    } while (0)
 
 #define PMIX_MODEX_CONSTRUCT(m)                         \
     do {                                                \
         memset((m), 0, sizeof(pmix_modex_data_t));      \
-    } while(0);
+    } while (0)
 
 #define PMIX_MODEX_DESTRUCT(m)                  \
     do {                                        \
         if (NULL != (m)->blob) {                \
             free((m)->blob);                    \
         }                                       \
-    } while(0);
+    } while (0)
 
 #define PMIX_MODEX_FREE(m, n)                           \
     do {                                                \
@@ -718,7 +718,7 @@ typedef struct {
             }                                           \
             free((m));                                  \
         }                                               \
-    } while(0);
+    } while (0)
 
 
 /****    CALLBACK FUNCTIONS FOR NON-BLOCKING OPERATIONS    ****/
@@ -959,13 +959,13 @@ pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc,
     do {                                                            \
         (_v)->type = PMIX_VAL_TYPE_ ## _field;                      \
         PMIX_VAL_FIELD_ ## _field((_v)) = _val;                     \
-    } while(0);
+    } while (0)
 
 #define PMIX_VAL_set_strdup(_v, _field, _val )       \
     do {                                                                \
         (_v)->type = PMIX_VAL_TYPE_ ## _field;                          \
         PMIX_VAL_FIELD_ ## _field((_v)) = strdup(_val);                 \
-    } while(0);
+    } while (0)
 
 #define PMIX_VAL_SET_int        PMIX_VAL_set_assign
 #define PMIX_VAL_SET_uint32_t   PMIX_VAL_set_assign

--- a/include/private/hash_string.h
+++ b/include/private/hash_string.h
@@ -42,7 +42,7 @@
         _hash ^= (_hash >> 11);               \
         (hash) = (_hash + (_hash << 15));     \
         (length)  = _len;                     \
-    } while(0)
+    } while (0)
 
 /**
  *  Compute the hash value
@@ -64,6 +64,6 @@
         _hash += (_hash << 3);                \
         _hash ^= (_hash >> 11);               \
         (hash) = (_hash + (_hash << 15));     \
-    } while(0)
+    } while (0)
 
 #endif  /* PMIX_HASH_STRING_H */

--- a/src/buffer_ops/buffer_ops.h
+++ b/src/buffer_ops/buffer_ops.h
@@ -59,7 +59,7 @@ bool pmix_value_cmp(pmix_value_t *p, pmix_value_t *p1);
         (b)->unpack_ptr = (b)->base_ptr;                \
         (d) = NULL;                                     \
         (s) = 0;                                        \
-    } while(0);
+    } while (0)
 
 #define PMIX_UNLOAD_BUFFER(b, d, s)             \
     do {                                        \
@@ -70,7 +70,7 @@ bool pmix_value_cmp(pmix_value_t *p, pmix_value_t *p1);
         (b)->bytes_allocated = 0;               \
         (b)->pack_ptr = NULL;                   \
         (b)->unpack_ptr = NULL;                 \
-    } while (0);
+    } while (0)
 
 
 /**

--- a/src/buffer_ops/internal.h
+++ b/src/buffer_ops/internal.h
@@ -212,7 +212,7 @@ PMIX_CLASS_DECLARATION(pmix_bfrop_type_info_t);
     _info->odti_print_fn = (pmix_bfrop_print_fn_t)(pr) ;            \
     pmix_pointer_array_set_item(&pmix_bfrop_types, (t), _info);     \
     ++pmix_bfrop_num_reg_types;                                     \
-} while(0);
+} while (0)
 
 /*
  * Implementations of API functions

--- a/src/class/pmix_list.h
+++ b/src/class/pmix_list.h
@@ -175,7 +175,7 @@ typedef struct pmix_list_t pmix_list_t;
             PMIX_RELEASE(it);                                    \
         }                                                       \
         PMIX_DESTRUCT(list);                                     \
-    } while(0);
+    } while (0)
 
 #define PMIX_LIST_RELEASE(list)                                 \
     do {                                                        \
@@ -184,7 +184,7 @@ typedef struct pmix_list_t pmix_list_t;
             PMIX_RELEASE(it);                                    \
         }                                                       \
         PMIX_RELEASE(list);                                      \
-    } while(0);
+    } while (0)
 
 
 /**

--- a/src/class/pmix_object.h
+++ b/src/class/pmix_object.h
@@ -288,11 +288,11 @@ static inline pmix_object_t *pmix_obj_new_debug(pmix_class_t* type, const char* 
     do {                                                        \
         ((pmix_object_t*)(OBJECT))->cls_init_file_name = FILE;  \
         ((pmix_object_t*)(OBJECT))->cls_init_lineno = LINENO;   \
-    } while(0)
+    } while (0)
 #define PMIX_SET_MAGIC_ID( OBJECT, VALUE )                       \
     do {                                                        \
         ((pmix_object_t*)(OBJECT))->obj_magic_id = (VALUE);     \
-    } while(0)
+    } while (0)
 #else
 #define PMIX_REMEMBER_FILE_AND_LINENO( OBJECT, FILE, LINENO )
 #define PMIX_SET_MAGIC_ID( OBJECT, VALUE )

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -277,7 +277,7 @@ PMIX_CLASS_DECLARATION(pmix_shift_caddy_t);
     event_assign(&((r)->ev), pmix_globals.evbase,     \
                  -1, EV_WRITE, (c), (r));             \
     event_active(&((r)->ev), EV_WRITE, 1);            \
-} while(0);
+} while (0)
 
 
 #define PMIX_WAIT_FOR_COMPLETION(a)             \
@@ -285,7 +285,7 @@ PMIX_CLASS_DECLARATION(pmix_shift_caddy_t);
         while ((a)) {                           \
             usleep(10);                         \
         }                                       \
-    } while (0);
+    } while (0)
 
 
 /****    GLOBAL STORAGE    ****/

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -140,7 +140,7 @@ static void _queue_message(int fd, short args, void *cbdata)
                        EV_WRITE, _queue_message, queue);                \
         event_priority_set(&queue->ev, 0);                              \
         event_active(&queue->ev, EV_WRITE, 1);                          \
-    } while(0);
+    } while (0)
 
 
 static pmix_status_t initialize_server_base(pmix_server_module_t *module)

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -121,7 +121,7 @@ typedef struct {
         (c)->hdr.tag = (t);                     \
         PMIX_RETAIN((p));                       \
         (c)->peer = (p);                        \
-    } while(0);
+    } while (0)
 
 #define PMIX_SND_CADDY(c, h, s)                                         \
     do {                                                                \
@@ -129,13 +129,13 @@ typedef struct {
         (void)memcpy(&(c)->hdr, &(h), sizeof(pmix_usock_hdr_t));        \
         PMIX_RETAIN((s));                                               \
         (c)->snd = (s);                                                 \
-    } while(0);
+    } while (0)
 
 #define PMIX_SETUP_COLLECTIVE(c, t)             \
     do {                                        \
         (c) = PMIX_NEW(pmix_trkr_caddy_t);      \
         (c)->trk = (t);                         \
-    } while(0);
+    } while (0)
 
 #define PMIX_EXECUTE_COLLECTIVE(c, t, f)                        \
     do {                                                        \
@@ -143,7 +143,7 @@ typedef struct {
         event_assign(&((c)->ev), pmix_globals.evbase, -1,       \
                      EV_WRITE, (f), (c));                       \
         event_active(&((c)->ev), EV_WRITE, 1);                  \
-    } while(0);
+    } while (0)
 
 
 int pmix_start_listening(struct sockaddr_un *address);

--- a/src/usock/usock.h
+++ b/src/usock/usock.h
@@ -136,7 +136,7 @@ PMIX_CLASS_DECLARATION(pmix_timer_t);
         pmix_output_verbose(10, pmix_globals.debug_output,              \
                             "event_assign returned %d", rc);            \
         event_active(&((ms)->ev), EV_WRITE, 1);                         \
-    } while(0);
+    } while (0)
 
 #define PMIX_ACTIVATE_POST_MSG(ms)                                      \
     do {                                                                \
@@ -146,7 +146,7 @@ PMIX_CLASS_DECLARATION(pmix_timer_t);
         event_assign(&((ms)->ev), pmix_globals.evbase, -1,              \
                      EV_WRITE, pmix_usock_process_msg, (ms));           \
         event_active(&((ms)->ev), EV_WRITE, 1);                         \
-    } while(0);
+    } while (0)
 
 #define CLOSE_THE_SOCKET(socket)                \
     do {                                        \
@@ -155,7 +155,7 @@ PMIX_CLASS_DECLARATION(pmix_timer_t);
             close(socket);                      \
             socket = -1;                        \
         }                                       \
-    } while(0)
+    } while (0)
 
 
 #define PMIX_TIMER_EVENT(s, f, d)                                       \
@@ -172,7 +172,7 @@ PMIX_CLASS_DECLARATION(pmix_timer_t);
                              (long)tv.tv_sec, (long)tv.tv_usec,         \
                              __FILE__, __LINE__));                      \
         event_add(&tm->ev, &tv);                                        \
-    }while(0);                                                          \
+    } while (0)
 
 
 /* usock common variables */

--- a/src/util/error.h
+++ b/src/util/error.h
@@ -34,7 +34,7 @@
         pmix_output(0, "PMIX ERROR: %s in file %s at line %d",      \
                     PMIx_Error_string((r)), __FILE__, __LINE__);    \
     }                                                               \
-}while(0);
+} while (0)
 
 #define PMIX_REPORT_ERROR(e)  \
 pmix_errhandler_invoke(e, NULL, 0, NULL, 0)

--- a/test/test_fence.c
+++ b/test/test_fence.c
@@ -64,7 +64,7 @@ static void add_noise(char *noise_param, char *my_nspace, int my_rank)
     } else {                                                                                                        \
         (void)snprintf(key, sizeof(key)-1, "key-f%d:%d", fence_num, ind);                                             \
     }                                                                                                               \
-} while (0);
+} while (0)
 
 #define PUT(dtype, data, flag, fence_num, ind, use_same_keys) do {                                                  \
     char key[50];                                                                                                   \
@@ -77,7 +77,7 @@ static void add_noise(char *noise_param, char *my_nspace, int my_rank)
         rc = PMIX_ERROR;                                                                                            \
     }                                                                                                               \
     PMIX_VALUE_DESTRUCT(&value);                                                                                    \
-} while (0);
+} while (0)
 
 #define GET(dtype, data, ns, r, fence_num, ind, use_same_keys, blocking, ok_notfnd) do {                        \
     char key[50];                                                                                                   \
@@ -137,7 +137,7 @@ static void add_noise(char *noise_param, char *my_nspace, int my_rank)
         TEST_VERBOSE(("%s:%d: GET OF %s from %s:%d SUCCEEDED", my_nspace, my_rank, key, ns, r));                 \
         PMIX_VALUE_RELEASE(val);                                                                                    \
     }                                                                                                               \
-} while(0);
+} while (0)
 
 #define FENCE(blocking, data_ex, pcs, nprocs) do {                              \
     if( blocking ){                                                             \
@@ -172,7 +172,7 @@ static void add_noise(char *noise_param, char *my_nspace, int my_rank)
         TEST_VERBOSE(("%s:%d: Fence successfully completed",                    \
                         my_nspace, my_rank));                                   \
     }                                                                           \
-} while (0);
+} while (0)
 
 int test_fence(test_params params, char *my_nspace, int my_rank)
 {


### PR DESCRIPTION
Remove extra semicolon from the end of do/while loops throughout
code, fix whitespace before and after the while keyword.

Fix an example which was not correctly providing a semicolon.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>