### PR TITLE
Increment the reference count in PMIx_Init

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -263,6 +263,7 @@ PMIX_EXPORT int PMIx_Init(pmix_proc_t *proc,
             (void)strncpy(proc->nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
             proc->rank = pmix_globals.myid.rank;
         }
+        ++pmix_globals.init_cntr;
         return PMIX_SUCCESS;
     }
     /* if we don't see the required info, then we cannot init */


### PR DESCRIPTION
The reference counting was broken which led PMIx_Finalize
to release resources early. This fixes the "use after free" scenarios
that I encountered.