### PR TITLE
Fix C++ usage of PMIx

### DIFF
--- a/include/pmix.h
+++ b/include/pmix.h
@@ -55,7 +55,7 @@
 #include <pmix/pmix_common.h>
 
 
- BEGIN_C_DECLS
+BEGIN_C_DECLS
 
 /****    PMIX API    ****/
 
@@ -406,5 +406,5 @@
  * when done with it */
  pmix_status_t PMIx_Resolve_nodes(const char *nspace, char **nodelist);
 
- END_C_DECLS
+END_C_DECLS
 #endif

--- a/include/pmix/pmix_common.h
+++ b/include/pmix/pmix_common.h
@@ -364,14 +364,14 @@ typedef enum {
 } pmix_persistence_t;
 
 /****    PMIX BYTE OBJECT    ****/
-typedef struct {
+typedef struct pmix_byte_object {
     char *bytes;
     size_t size;
 } pmix_byte_object_t;
 
 
 /****    PMIX PROC OBJECT    ****/
-typedef struct {
+typedef struct pmix_proc {
     char nspace[PMIX_MAX_NSLEN+1];
     int rank;
 } pmix_proc_t;
@@ -403,18 +403,18 @@ typedef struct {
 
 
 /****    PMIX VALUE STRUCT    ****/
-struct pmix_info_t;
+struct pmix_info;
 
-typedef struct {
+typedef struct pmix_info_array {
     size_t size;
-    struct pmix_info_t *array;
+    struct pmix_info *array;
 } pmix_info_array_t;
 /* NOTE: operations can supply a collection of values under
  * a single key by passing a pmix_value_t containing an
  * array of type PMIX_INFO_ARRAY, with each array element
  * containing its own pmix_info_t object */
 
-typedef struct {
+typedef struct pmix_value {
     pmix_data_type_t type;
     union {
         bool flag;
@@ -517,7 +517,7 @@ void pmix_value_load(pmix_value_t *v, void *data, pmix_data_type_t type);
 
 
 /****    PMIX INFO STRUCT    ****/
-typedef struct {
+typedef struct pmix_info {
     char key[PMIX_MAX_KEYLEN+1];  // ensure room for the NULL terminator
     bool required;                // defaults to optional (i.e., required=false)
     pmix_value_t value;
@@ -563,7 +563,7 @@ typedef struct {
     (m)->required = false;
 
 /****    PMIX LOOKUP RETURN STRUCT    ****/
-typedef struct {
+typedef struct pmix_pdata {
     pmix_proc_t proc;
     char key[PMIX_MAX_KEYLEN+1];  // ensure room for the NULL terminator
     pmix_value_t value;
@@ -615,7 +615,7 @@ typedef struct {
 
 
 /****    PMIX APP STRUCT    ****/
-typedef struct {
+typedef struct pmix_app {
     char *cmd;
     int argc;
     char **argv;
@@ -679,7 +679,7 @@ typedef struct {
     } while (0)
 
 /****    PMIX MODEX STRUCT    ****/
-typedef struct {
+typedef struct pmix_modex_data {
     char nspace[PMIX_MAX_NSLEN+1];
     int rank;
     uint8_t *blob;

--- a/src/buffer_ops/copy.c
+++ b/src/buffer_ops/copy.c
@@ -310,7 +310,7 @@ pmix_status_t pmix_value_xfer(pmix_value_t *p, pmix_value_t *src)
     case PMIX_INFO_ARRAY:
         p->data.array.size = src->data.array.size;
         if (0 < src->data.array.size) {
-            p->data.array.array = (struct pmix_info_t*)malloc(src->data.array.size * sizeof(pmix_info_t));
+            p->data.array.array = (struct pmix_info *)malloc(src->data.array.size * sizeof(pmix_info_t));
             p1 = (pmix_info_t*)p->data.array.array;
             s1 = (pmix_info_t*)src->data.array.array;
             memcpy(p1, s1, src->data.array.size * sizeof(pmix_info_t));
@@ -418,7 +418,7 @@ int pmix_bfrop_copy_array(pmix_info_array_t **dest,
 
     *dest = (pmix_info_array_t*)malloc(sizeof(pmix_info_array_t));
     (*dest)->size = src->size;
-    (*dest)->array = (struct pmix_info_t*)malloc(src->size * sizeof(pmix_info_t));
+    (*dest)->array = (struct pmix_info *)malloc(src->size * sizeof(pmix_info_t));
     d1 = (pmix_info_t*)(*dest)->array;
     s1 = (pmix_info_t*)src->array;
     memcpy(d1, s1, src->size * sizeof(pmix_info_t));

--- a/src/buffer_ops/unpack.c
+++ b/src/buffer_ops/unpack.c
@@ -974,7 +974,7 @@ int pmix_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
             return ret;
         }
         if (0 < ptr[i].size) {
-            ptr[i].array = (struct pmix_info_t*)malloc(ptr[i].size * sizeof(pmix_info_t));
+            ptr[i].array = (struct pmix_info *)malloc(ptr[i].size * sizeof(pmix_info_t));
             m=ptr[i].size;
             if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_value(buffer, ptr[i].array, &m, PMIX_INFO))) {
                 return ret;

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -487,7 +487,7 @@ static void _getnbfn(int fd, short flags, void *cbdata)
         val->type = PMIX_INFO_ARRAY;
         val->data.array.size = nvals;
         PMIX_INFO_CREATE(iptr, nvals);
-        val->data.array.array = (struct pmix_info_t*)iptr;
+        val->data.array.array = (struct pmix_info *)iptr;
         for (n=0; n < (size_t)results.size && n < nvals; n++) {
             if (NULL != (info = (pmix_info_t*)pmix_pointer_array_get_item(&results, n))) {
                 (void)strncpy(iptr[n].key, info->key, PMIX_MAX_KEYLEN);


### PR DESCRIPTION
C++ mandates that we provide a name to each struct - i.e., it doesn't like:

typedef struct {
...
} foo_t;

Instead, it requires:

typedef struct foo {
...
} foo_t;

So make it happy and let C++ apps use PMIx