### PR TITLE
Backport the relevant changes from OMPI

### DIFF
--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -148,6 +148,7 @@ static pmix_status_t initialize_server_base(pmix_server_module_t *module)
     int debug_level;
     char *tdir, *evar;
     pid_t pid;
+    char * pmix_pid;
 
     /* initialize the output system */
     if (!pmix_output_init()) {
@@ -223,7 +224,16 @@ static pmix_status_t initialize_server_base(pmix_server_module_t *module)
     /* now set the address - we use the pid here to reduce collisions */
     memset(&myaddress, 0, sizeof(struct sockaddr_un));
     myaddress.sun_family = AF_UNIX;
-    snprintf(myaddress.sun_path, sizeof(myaddress.sun_path)-1, "%s/pmix-%d", tdir, pid);
+    asprintf(&pmix_pid, "pmix-%d", pid);
+    // If the above set temporary directory name plus the pmix-PID string
+    // plus the '/' separator are too long, just fail, so the caller
+    // may provide the user with a proper help... *Cough*, *Cough* OSX...
+    if ((strlen(tdir) + strlen(pmix_pid) + 1) > sizeof(myaddress.sun_path)-1) {
+        free(pmix_pid);
+        return PMIX_ERR_INVALID_LENGTH;
+    }
+    snprintf(myaddress.sun_path, sizeof(myaddress.sun_path)-1, "%s/%s", tdir, pmix_pid);
+    free(pmix_pid);
     asprintf(&myuri, "%s:%lu:%s", pmix_globals.myid.nspace, (unsigned long)pmix_globals.myid.rank, myaddress.sun_path);
 
 

--- a/src/server/pmix_server_listener.c
+++ b/src/server/pmix_server_listener.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Artem Y. Polyakov <artpol84@gmail.com>.
@@ -75,41 +75,41 @@ pmix_status_t pmix_start_listening(struct sockaddr_un *address)
 {
     int flags;
     pmix_status_t rc;
-    unsigned int addrlen;
+    socklen_t addrlen;
     char *ptr;
 
     /* create a listen socket for incoming connection attempts */
     pmix_server_globals.listen_socket = socket(PF_UNIX, SOCK_STREAM, 0);
     if (pmix_server_globals.listen_socket < 0) {
-        printf("%s:%d socket() failed", __FILE__, __LINE__);
+        printf("%s:%d socket() failed\n", __FILE__, __LINE__);
         return PMIX_ERROR;
     }
 
     addrlen = sizeof(struct sockaddr_un);
     if (bind(pmix_server_globals.listen_socket, (struct sockaddr*)address, addrlen) < 0) {
-        printf("%s:%d bind() failed", __FILE__, __LINE__);
+        printf("%s:%d bind() failed\n", __FILE__, __LINE__);
         return PMIX_ERROR;
     }
     /* set the mode as required */
     if (0 != chmod(address->sun_path, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP)) {
-        pmix_output(0, "CANNOT CHMOD %s", address->sun_path);
+        pmix_output(0, "CANNOT CHMOD %s\n", address->sun_path);
         return PMIX_ERROR;
     }
 
     /* setup listen backlog to maximum allowed by kernel */
     if (listen(pmix_server_globals.listen_socket, SOMAXCONN) < 0) {
-        printf("%s:%d listen() failed", __FILE__, __LINE__);
+        printf("%s:%d listen() failed\n", __FILE__, __LINE__);
         return PMIX_ERROR;
     }
 
     /* set socket up to be non-blocking, otherwise accept could block */
     if ((flags = fcntl(pmix_server_globals.listen_socket, F_GETFL, 0)) < 0) {
-        printf("%s:%d fcntl(F_GETFL) failed", __FILE__, __LINE__);
+        printf("%s:%d fcntl(F_GETFL) failed\n", __FILE__, __LINE__);
         return PMIX_ERROR;
     }
     flags |= O_NONBLOCK;
     if (fcntl(pmix_server_globals.listen_socket, F_SETFL, flags) < 0) {
-        printf("%s:%d fcntl(F_SETFL) failed", __FILE__, __LINE__);
+        printf("%s:%d fcntl(F_SETFL) failed\n", __FILE__, __LINE__);
         return PMIX_ERROR;
     }
 


### PR DESCRIPTION
If the tmpdir name is too long, then return an error so the host RM can know we couldn't setup the rendezvous point. Also, minor cleanup of some debug output

@artpol84 Can you please take a look? I think I captured everything from Rainer's original PR