### PR TITLE
Return sensible errors from PMI1 when RM registers incomplete namespace

### DIFF
--- a/src/client/pmi1.c
+++ b/src/client/pmi1.c
@@ -266,7 +266,8 @@ PMIX_EXPORT int PMI_Get_size(int *size)
     PMIX_INFO_CONSTRUCT(&info[0]);
     PMIX_INFO_LOAD(&info[0], PMIX_OPTIONAL, &val_optinal, PMIX_BOOL);
 
-    if (PMIX_SUCCESS == PMIx_Get(&proc, PMIX_JOB_SIZE, info, 1, &val)) {
+    rc = PMIx_Get(&proc, PMIX_JOB_SIZE, info, 1, &val);
+    if (PMIX_SUCCESS == rc) {
         rc = convert_int(size, val);
         PMIX_VALUE_RELEASE(val);
     }
@@ -311,7 +312,8 @@ PMIX_EXPORT int PMI_Get_universe_size(int *size)
     PMIX_INFO_CONSTRUCT(&info[0]);
     PMIX_INFO_LOAD(&info[0], PMIX_OPTIONAL, &val_optinal, PMIX_BOOL);
 
-    if (PMIX_SUCCESS == PMIx_Get(&proc, PMIX_UNIV_SIZE, info, 1, &val)) {
+    rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, info, 1, &val);
+    if (PMIX_SUCCESS == rc) {
         rc = convert_int(size, val);
         PMIX_VALUE_RELEASE(val);
     }
@@ -344,7 +346,8 @@ PMIX_EXPORT int PMI_Get_appnum(int *appnum)
     PMIX_INFO_CONSTRUCT(&info[0]);
     PMIX_INFO_LOAD(&info[0], PMIX_OPTIONAL, &val_optinal, PMIX_BOOL);
 
-    if (PMIX_SUCCESS == PMIx_Get(&proc, PMIX_APPNUM, info, 1, &val)) {
+    rc = PMIx_Get(&proc, PMIX_APPNUM, info, 1, &val);
+    if (PMIX_SUCCESS == rc) {
         rc = convert_int(appnum, val);
         PMIX_VALUE_RELEASE(val);
     }
@@ -491,7 +494,8 @@ PMIX_EXPORT int PMI_Get_clique_size(int *size)
     PMIX_INFO_CONSTRUCT(&info[0]);
     PMIX_INFO_LOAD(&info[0], PMIX_OPTIONAL, &val_optinal, PMIX_BOOL);
 
-    if (PMIX_SUCCESS == PMIx_Get(&myproc, PMIX_LOCAL_SIZE, info, 1, &val)) {
+    rc = PMIx_Get(&myproc, PMIX_LOCAL_SIZE, info, 1, &val);
+    if (PMIX_SUCCESS == rc) {
         rc = convert_int(size, val);
         PMIX_VALUE_RELEASE(val);
     }
@@ -514,7 +518,8 @@ PMIX_EXPORT int PMI_Get_clique_ranks(int ranks[], int length)
         return PMI_ERR_INVALID_ARGS;
     }
 
-    if (PMIX_SUCCESS == PMIx_Get(&myproc, PMIX_LOCAL_PEERS, NULL, 0, &val)) {
+    rc = PMIx_Get(&myproc, PMIX_LOCAL_PEERS, NULL, 0, &val);
+    if (PMIX_SUCCESS == rc) {
         /* kv will contain a string of comma-separated
          * ranks on my node */
         rks = pmix_argv_split(val->data.string, ',');

--- a/test/utils.c
+++ b/test/utils.c
@@ -47,7 +47,7 @@ static void set_namespace(int nprocs, char *ranks, char *name)
 {
     size_t ninfo;
     pmix_info_t *info;
-    ninfo = 6;
+    ninfo = 8;
     char *regex, *ppn;
 
     PMIX_INFO_CREATE(info, ninfo);
@@ -76,6 +76,14 @@ static void set_namespace(int nprocs, char *ranks, char *name)
     (void)strncpy(info[5].key, PMIX_PROC_MAP, PMIX_MAX_KEYLEN);
     info[5].value.type = PMIX_STRING;
     info[5].value.data.string = ppn;
+
+    (void)strncpy(info[6].key, PMIX_JOB_SIZE, PMIX_MAX_KEYLEN);
+    info[6].value.type = PMIX_UINT32;
+    info[6].value.data.uint32 = nprocs;
+
+    (void)strncpy(info[7].key, PMIX_APPNUM, PMIX_MAX_KEYLEN);
+    info[7].value.type = PMIX_UINT32;
+    info[7].value.data.uint32 = getpid ();
 
     int in_progress = 1, rc;
     if (PMIX_SUCCESS == (rc = PMIx_server_register_nspace(name, nprocs, info, ninfo, release_cb, &in_progress))) {


### PR DESCRIPTION
Several PMI1 functions returned success without setting their parameter when `PMIx_Get()` failed.  Fix the logic in those functions to return the (PMI1-converted) error code of `PMIx_Get()` when it fails.  Also define PMIX_JOB_SIZE and PMIX_APPNUM in the `pmix_test` namespace so the `pmi_client` test no longer fails as reported in #83.

Note: `PMI2_Init()` returns PMIX_UNIV_SIZE for its `size` parameter.  Perhaps `PMI1_Get_size()` should use that instead of PMIX_JOB_SIZE?  I wasn't too sure about that one so I left it as is.