### PR TITLE
security: validate connections with SO_PEERCRED + misc fixes

### DIFF
--- a/include/pmix/pmix_common.h
+++ b/include/pmix/pmix_common.h
@@ -97,6 +97,9 @@ BEGIN_C_DECLS
 #define PMIX_USERID                "pmix.euid"              // (uint32_t) effective user id
 #define PMIX_GRPID                 "pmix.egid"              // (uint32_t) effective group id
 
+/* attributes for the rendezvous socket  */
+#define PMIX_SOCKET_MODE           "pmix.sockmode"          // (uint32_t) POSIX mode_t (9 bits valid)
+
 /* general proc-level attributes */
 #define PMIX_CPUSET                "pmix.cpuset"            // (char*) hwloc bitmap applied to proc upon launch
 #define PMIX_CREDENTIAL            "pmix.cred"              // (char*) security credential assigned to proc

--- a/src/sec/pmix_munge.c
+++ b/src/sec/pmix_munge.c
@@ -118,7 +118,7 @@ static int validate_cred(pmix_peer_t *peer, char *cred)
     munge_err_t rc;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
-                        "sec: munge validate_cred %s", cred);
+                        "sec: munge validate_cred %s", cred ? cred : "NULL");
 
     /* parse the inbound string */
     if (EMUNGE_SUCCESS != (rc = munge_decode(cred, NULL, NULL, NULL, &uid, &gid))) {

--- a/src/sec/pmix_sec.c
+++ b/src/sec/pmix_sec.c
@@ -61,12 +61,6 @@
 #define PMIX_SEC_NAVAIL  3
 
 static pmix_sec_base_module_t *all[] = {
-#if PMIX_HAVE_MUNGE
-    /* Start the array with the least heavy option, if available */
-    &pmix_munge_module,
-#endif
-
-    /* Our native module should always be the lowest priority */
     &pmix_native_module,
 
     /* Always end the array with a NULL */

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -251,6 +251,9 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
     pmix_status_t rc;
     size_t n;
     pmix_kval_t kv;
+    uid_t sockuid = -1;
+    gid_t sockgid = -1;
+    mode_t sockmode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH;
 
     ++pmix_globals.init_cntr;
     if (1 < pmix_globals.init_cntr) {
@@ -284,10 +287,10 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
         for (n=0; n < ninfo; n++) {
             if (0 == strcmp(info[n].key, PMIX_USERID)) {
                 /* the userid is in the uint32_t storage */
-                chown(myaddress.sun_path, info[n].value.data.uint32, -1);
+                sockuid = info[n].value.data.uint32;
             } else if (0 == strcmp(info[n].key, PMIX_GRPID)) {
                /* the grpid is in the uint32_t storage */
-                chown(myaddress.sun_path, -1, info[n].value.data.uint32);
+                sockgid = info[n].value.data.uint32;
             }
         }
     }
@@ -300,32 +303,27 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
     pmix_list_append(&pmix_usock_globals.posted_recvs, &req->super);
 
     /* start listening */
-    if (PMIX_SUCCESS != pmix_start_listening(&myaddress)) {
+    if (PMIX_SUCCESS != pmix_start_listening(&myaddress, sockmode, sockuid, sockgid)) {
         PMIx_server_finalize();
         return PMIX_ERR_INIT;
     }
 
-    /* check the info keys for a directive about the uid/gid
-     * to be set for the rendezvous file, and any info we
+    /* check the info keys for info we
      * need to provide to every client */
     if (NULL != info) {
         PMIX_CONSTRUCT(&kv, pmix_kval_t);
         for (n=0; n < ninfo; n++) {
-            if (0 == strcmp(info[n].key, PMIX_USERID)) {
-                /* the userid is in the uint32_t storage */
-                chown(myaddress.sun_path, info[n].value.data.uint32, -1);
-            } else if (0 == strcmp(info[n].key, PMIX_GRPID)) {
-                /* the grpid is in the uint32_t storage */
-                chown(myaddress.sun_path, -1, info[n].value.data.uint32);
-            } else {
-                /* store and pass along to every client */
-                kv.key = info[n].key;
-                kv.value = &info[n].value;
-                if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(&pmix_server_globals.gdata, &kv, 1, PMIX_KVAL))) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_DESTRUCT(&kv);
-                    return rc;
-                }
+            if (0 == strcmp(info[n].key, PMIX_USERID))
+                continue;
+            if (0 == strcmp(info[n].key, PMIX_GRPID))
+                continue;
+            /* store and pass along to every client */
+            kv.key = info[n].key;
+            kv.value = &info[n].value;
+            if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(&pmix_server_globals.gdata, &kv, 1, PMIX_KVAL))) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_DESTRUCT(&kv);
+                return rc;
             }
         }
         /* protect the incoming data */

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -291,6 +291,8 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
             } else if (0 == strcmp(info[n].key, PMIX_GRPID)) {
                /* the grpid is in the uint32_t storage */
                 sockgid = info[n].value.data.uint32;
+            } else if (0 == strcmp(info[n].key, PMIX_SOCKET_MODE)) {
+                sockmode = info[n].value.data.uint32 & 0777;
             }
         }
     }
@@ -316,6 +318,8 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
             if (0 == strcmp(info[n].key, PMIX_USERID))
                 continue;
             if (0 == strcmp(info[n].key, PMIX_GRPID))
+                continue;
+            if (0 == strcmp(info[n].key, PMIX_SOCKET_MODE))
                 continue;
             /* store and pass along to every client */
             kv.key = info[n].key;

--- a/src/server/pmix_server_listener.c
+++ b/src/server/pmix_server_listener.c
@@ -429,21 +429,22 @@ static pmix_status_t pmix_server_authenticate(int sd, int *out_rank,
     }
 
     /* see if there is a credential */
-    if (csize < hdr.nbytes) {
+    if (csize < hdr.nbytes)
         cred = (char*)(msg + csize);
-        if (NULL != cred && NULL != pmix_sec.validate_cred) {
-            if (PMIX_SUCCESS != (rc = pmix_sec.validate_cred(psave, cred))) {
-                pmix_output_verbose(2, pmix_globals.debug_output,
-                                    "validation of client credential failed");
-                free(msg);
-                pmix_pointer_array_set_item(&pmix_server_globals.clients, psave->index, NULL);
-                PMIX_RELEASE(psave);
-                /* send an error reply to the client */
-                goto error;
-            }
+    else
+        cred = NULL;
+    if (NULL != pmix_sec.validate_cred) {
+        if (PMIX_SUCCESS != (rc = pmix_sec.validate_cred(psave, cred))) {
             pmix_output_verbose(2, pmix_globals.debug_output,
-                                "client credential validated");
+                                "validation of client credential failed");
+            free(msg);
+            pmix_pointer_array_set_item(&pmix_server_globals.clients, psave->index, NULL);
+            PMIX_RELEASE(psave);
+            /* send an error reply to the client */
+            goto error;
         }
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "client credential validated");
     }
     free(msg);
 

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -146,7 +146,8 @@ typedef struct {
     } while (0)
 
 
-pmix_status_t pmix_start_listening(struct sockaddr_un *address);
+pmix_status_t pmix_start_listening(struct sockaddr_un *address,
+		                   mode_t mode, uid_t sockuid, gid_t sockgid);
 void pmix_stop_listening(void);
 
 bool pmix_server_trk_update(pmix_server_trkr_t *trk);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -29,6 +29,7 @@ headers = test_common.h cli_stages.h server_callbacks.h utils.h test_fence.h tes
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/src/api
 
+noinst_SCRIPTS = pmix_client_otheruser.sh
 noinst_PROGRAMS = pmi_client pmi2_client
 if !WANT_HIDDEN
 noinst_PROGRAMS += pmix_test pmix_client pmix_regex
@@ -64,3 +65,4 @@ pmix_regex_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 pmix_regex_LDADD = \
 	$(top_builddir)/libpmix.la
 
+EXTRA_DIST = $(noinst_SCRIPTS)

--- a/test/pmix_client_otheruser.sh
+++ b/test/pmix_client_otheruser.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+OTHERUSER=dummy
+
+# To test sec:native we run client as a different user e.g.
+#
+#  ./pmix_test -e ./pmix_client_otheruser.sh
+#
+# Prerequisites:
+# - ensure directories leading up to source tree are o+x
+# - add dummy user and set OTHERUSER to its name
+# - give yourself passwordless sudo capability to that user
+#
+# The test should fail with message similar to
+#   PMIX ERROR: INVALID-CREDENTIAL in file 
+#       ../src/server/pmix_server_listener.c at line 524
+#
+
+sudo --user $OTHERUSER --preserve-env ./pmix_client $*

--- a/test/pmix_test.c
+++ b/test/pmix_test.c
@@ -81,7 +81,12 @@ int main(int argc, char **argv)
     }
 
     /* setup the server library */
-    if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, NULL, 0))) {
+    pmix_info_t info[1];
+    (void)strncpy(info[0].key, PMIX_SOCKET_MODE, PMIX_MAX_KEYLEN);
+    info[0].value.type = PMIX_UINT32;
+    info[0].value.data.uint32 = 0666;
+
+    if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, info, 1))) {
         TEST_ERROR(("Init failed with error %d", rc));
         FREE_TEST_PARAMS(params);
         return rc;


### PR DESCRIPTION
This PR changes the way that the "native" security module works, as proposed in #91.  Instead of checking a client-supplied credential against the uid/gid registered by the server, send a NULL credential and validate a `struct ucred` from SO_PEERCRED against the uid/gid registered by the server.

This also closes a vulnerability where a client could bypass a security module's `validate_cred` method by sending a NULL cred.

Finally,  munge is removed from the list of security modules, since only UNIX domain socket connections are supported by PMIx presently, and it adds latency to the synchronous connect handshake of clients without improving security over SO_PEERCRED.

Testing:
* The fact that the "native" module no longer has a `create_cred` method means the client sends an empty cred; so the fact debug logs show its `validate_cred` method being called (where before it wasn't) indicate that NULL cred vulnerability is fixed.
* debug logs show ucred values are as expected, and that validation is successful
* I've run my RM with its PMIx server and PMI1 client (linked against libpmix.so) many times without issue
* Briefly tried `PMIX_DEBUG=5 ./pmix_test -n 16 -e ./pmix_client` and all looks OK.