### PR TITLE
add support for "preconnected" clients

### DIFF
--- a/include/pmix/pmix_common.h
+++ b/include/pmix/pmix_common.h
@@ -99,6 +99,8 @@ BEGIN_C_DECLS
 
 /* attributes for the rendezvous socket  */
 #define PMIX_SOCKET_MODE           "pmix.sockmode"          // (uint32_t) POSIX mode_t (9 bits valid)
+#define PMIX_SOCKET_FILENAME       "pmix.sockname"          // (char*) filename to use for socket
+#define PMIX_SOCKET_SUPPRESS       "pmix.nosock"            // (bool) suppress creation/listening on socket
 
 /* general proc-level attributes */
 #define PMIX_CPUSET                "pmix.cpuset"            // (char*) hwloc bitmap applied to proc upon launch

--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -387,6 +387,12 @@ pmix_status_t PMIx_server_register_client(const pmix_proc_t *proc,
                                           void *server_object,
                                           pmix_op_cbfunc_t cbfunc, void *cbdata);
 
+/* Register a "pre-connected" socket for the specified client.
+ * The resource manager must arrange for this fd to remain open
+ * across fork/exec when the client is started, and for
+ * PMIX_SERVER_FD=fd to be set in the client's environment. */
+pmix_status_t PMIx_server_register_client_fd(const pmix_proc_t *proc, int fd);
+
 /* Deregister a client and purge all data relating to it. The
  * deregister_nspace API will automatically delete all client
  * info for that nspace - this API is therefore intended solely

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -192,18 +192,16 @@ static void job_data(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
     cb->active = false;
 }
 
-static pmix_status_t connect_to_server(struct sockaddr_un *address, void *cbdata)
+static pmix_status_t setup_server(int sd, void *cbdata)
 {
-    int sd;
     pmix_status_t ret;
     pmix_cmd_t cmd = PMIX_REQ_CMD;
     pmix_buffer_t *req;
 
-    if (PMIX_SUCCESS != (ret=usock_connect((struct sockaddr *)address, &sd))) {
-        PMIX_ERROR_LOG(ret);
-        return ret;
-    }
+    /* mark the connection as made */
+    pmix_globals.connected = true;
     pmix_client_globals.myserver.sd = sd;
+
     /* setup recv event */
     event_assign(&pmix_client_globals.myserver.recv_event,
                  pmix_globals.evbase,
@@ -244,7 +242,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
                           pmix_info_t info[], size_t ninfo)
 {
     char **uri, *evar;
-    int rc, debug_level;
+    int rc, debug_level, sd;
     struct sockaddr_un address;
     pmix_nspace_t *nsptr;
     pmix_cb_t cb;
@@ -404,8 +402,18 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
     /* setup an object to track server connection */
     PMIX_CONSTRUCT(&cb, pmix_cb_t);
     cb.active = true;
+
     /* connect to the server - returns job info if successful */
-    if (PMIX_SUCCESS != (rc = connect_to_server(&address, &cb))){
+    if (NULL != (evar = getenv("PMIX_SERVER_FD"))) {
+        sd = strtoul(evar, NULL, 10);
+        unsetenv("PMIX_SERVER_FD");
+    } else {
+        rc = usock_connect((struct sockaddr *)&address, &sd);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+        }
+    }
+    if (PMIX_SUCCESS != rc || PMIX_SUCCESS != (rc = setup_server (sd, &cb))) {
         PMIX_DESTRUCT(&cb);
         pmix_stop_progress_thread(pmix_globals.evbase);
         pmix_sec_finalize();
@@ -1312,9 +1320,6 @@ void pmix_client_process_nspace_blob(const char *nspace, pmix_buffer_t *bptr)
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "sock_peer_try_connect: Connection across to server succeeded");
-
-    /* mark the connection as made */
-    pmix_globals.connected = true;
 
     pmix_usock_set_nonblocking(sd);
 

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -351,14 +351,6 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
     memset(&address, 0, sizeof(struct sockaddr_un));
     address.sun_family = AF_UNIX;
     snprintf(address.sun_path, sizeof(address.sun_path)-1, "%s", uri[2]);
-    /* if the rendezvous file doesn't exist, that's an error */
-    if (0 != access(uri[2], R_OK)) {
-        pmix_argv_free(uri);
-        pmix_output_close(pmix_globals.debug_output);
-        pmix_output_finalize();
-        pmix_class_finalize();
-        return PMIX_ERR_NOT_FOUND;
-    }
     pmix_argv_free(uri);
 
     /* we also require our rank */

--- a/src/server/pmix_server_listener.c
+++ b/src/server/pmix_server_listener.c
@@ -202,9 +202,9 @@ static void activate_pending(int sd)
     /* throw it into our event library for processing */
     pending_connection = PMIX_NEW(pmix_pending_connection_t);
     pending_connection->sd = sd;
-    event_assign(&pending_connection->ev, pmix_globals.evbase, -1,
-                 EV_WRITE, connection_handler, pending_connection);
-    event_active(&pending_connection->ev, EV_WRITE, 1);
+    event_assign(&pending_connection->ev, pmix_globals.evbase, sd,
+                 EV_READ, connection_handler, pending_connection);
+    event_add(&pending_connection->ev, NULL);
 }
 
 static void* listen_thread(void *obj)

--- a/src/server/pmix_server_listener.c
+++ b/src/server/pmix_server_listener.c
@@ -198,7 +198,6 @@ void pmix_stop_listening(void)
 static void* listen_thread(void *obj)
 {
     int rc, max, accepted_connections;
-    socklen_t addrlen = sizeof(struct sockaddr_storage);
     pmix_pending_connection_t *pending_connection;
     struct timeval timeout;
     fd_set readfds;
@@ -260,8 +259,7 @@ static void* listen_thread(void *obj)
             event_assign(&pending_connection->ev, pmix_globals.evbase, -1,
                          EV_WRITE, connection_handler, pending_connection);
             pending_connection->sd = accept(pmix_server_globals.listen_socket,
-                                            (struct sockaddr*)&(pending_connection->addr),
-                                            &addrlen);
+                                            NULL, NULL);
             if (pending_connection->sd < 0) {
                 PMIX_RELEASE(pending_connection);
                 if (pmix_socket_errno != EAGAIN ||

--- a/src/server/pmix_server_listener.c
+++ b/src/server/pmix_server_listener.c
@@ -302,6 +302,14 @@ static void listener_cb(int incoming_sd)
     activate_pending(incoming_sd);
 }
 
+PMIX_EXPORT pmix_status_t PMIx_server_register_client_fd(const pmix_proc_t *proc, int fd)
+{
+    pmix_output_verbose(8, pmix_globals.debug_output,
+                        "register_client_fd %s:%d fd=%d",
+                        proc->nspace, proc->rank, fd);
+    activate_pending(fd);
+}
+
 static pmix_status_t lookup_nspace (const char *nspace, pmix_nspace_t **np)
 {
     pmix_nspace_t *nptr = NULL;

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -89,7 +89,6 @@ typedef struct {
     pmix_object_t super;
     pmix_event_t ev;
     int sd;
-    struct sockaddr_storage addr;
 } pmix_pending_connection_t;
 PMIX_CLASS_DECLARATION(pmix_pending_connection_t);
 

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -88,6 +88,7 @@ PMIX_CLASS_DECLARATION(pmix_dmdx_local_t);
 typedef struct {
     pmix_object_t super;
     pmix_event_t ev;
+    pmix_proc_t proc;
     int sd;
 } pmix_pending_connection_t;
 PMIX_CLASS_DECLARATION(pmix_pending_connection_t);


### PR DESCRIPTION
This PR adds support for a slightly more efficient mode of wiring up clients, in which the resource manager calls `socketpair(2)`, tells PMIx about one fd, and passes the other fd to the client via a PMIX_SERVER_FD environment varaible, as discussed in #90.

One API function was added to support this, which can be called right after `PMIx_server_register_client()`:

```C
/* Register a "pre-connected" socket for the specified client.
 * The resource manager must arrange for this fd to remain open
 * across fork/exec when the client is started, and for
 * PMIX_SERVER_FD=fd to be set in the client's environment. */
pmix_status_t PMIx_server_register_client_fd(const pmix_proc_t *proc, int fd);
```

For clients connected in this way, the `init-auth` handshake is disabled.  Since the connection was established by the server, it is "pre-authenticated".

There are still some unresolved issues with this PR:
- [x] find some way to ask `PMIx_server_init()` not to create the UNIX domain socket if it is not to be used (one less thing to cleanup/protect)
- [ ] client `PMIx_Init()` should ignore PMIX_SERVER_URI if PMIX_SERVER_FD is set
- [ ] find some way for  `PMIx_server_setup_fork()` to set PMIX_SERVER_FD
- [ ] add option to `pmix_test` to run this way for testing

Despite those gaps, it is working well with my test RM integration and seems to speed things up a bit when launching a large number of clients.

Any feedback appreciated!