### PR TITLE
add missing include files

### DIFF
--- a/include/pmix/pmix_common.h
+++ b/include/pmix/pmix_common.h
@@ -1,6 +1,8 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -56,6 +58,12 @@
 #include <string.h>
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h> /* for struct timeval */
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h> /* for uid_t and gid_t */
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h> /* for uid_t and gid_t */
 #endif
 
 BEGIN_C_DECLS


### PR DESCRIPTION
pmix cannot be built on alpine linux because of some missing includes.
uid_t and gid_t are defined in unistd.h or sys/types.h, and unistd.h
is not indirectly pulled under alpine linux, so do it manually.

Thanks N.L.K Nguyen for the report