### PR TITLE
Provide a key by which users can register a callback object to be returned whenever the registered event handler is invoked

### DIFF
--- a/include/pmix/pmix_common.h
+++ b/include/pmix/pmix_common.h
@@ -211,6 +211,10 @@ BEGIN_C_DECLS
 #define PMIX_EVENT_AFFECTED_PROC            "pmix.evproc"           // (pmix_proc_t) single proc that was affected
 #define PMIX_EVENT_AFFECTED_PROCS           "pmix.evaffected"       // (pmix_proc_t*) array of pmix_proc_t defining affected procs
 #define PMIX_EVENT_NON_DEFAULT              "pmix.evnondef"         // (bool) event is not to be delivered to default event handlers
+#define PMIX_EVENT_RETURN_OBJECT            "pmix.evobject"         // (void*) object to be returned whenever the registered cbfunc is invoked
+                                                                    //     NOTE: the object will _only_ be returned to the process that
+                                                                    //           registered it
+
 /* fault tolerance-related events */
 #define PMIX_EVENT_TERMINATE_SESSION        "pmix.evterm.sess"      // (bool) RM intends to terminate session
 #define PMIX_EVENT_TERMINATE_JOB            "pmix.evterm.job"       // (bool) RM intends to terminate this job

--- a/src/event/pmix_event.h
+++ b/src/event/pmix_event.h
@@ -38,6 +38,7 @@ typedef struct {
     size_t index;
     pmix_status_t code;
     pmix_notification_fn_t evhdlr;
+    void *cbobject;
 } pmix_single_event_t;
 PMIX_CLASS_DECLARATION(pmix_single_event_t);
 
@@ -51,6 +52,7 @@ typedef struct {
     pmix_status_t *codes;
     size_t ncodes;
     pmix_notification_fn_t evhdlr;
+    void *cbobject;
 } pmix_multi_event_t;
 PMIX_CLASS_DECLARATION(pmix_multi_event_t);
 
@@ -60,6 +62,7 @@ typedef struct {
     char *name;
     size_t index;
     pmix_notification_fn_t evhdlr;
+    void *cbobject;
 } pmix_default_event_t;
 PMIX_CLASS_DECLARATION(pmix_default_event_t);
 

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -226,6 +226,8 @@ static void progress_local_event_hdlr(pmix_status_t status,
             if (sing->code == chain->status) {
                 PMIX_RETAIN(chain);
                 chain->sing = sing;
+                /* add any cbobject - the info struct for it is at the end */
+                chain->info[chain->ninfo-1].value.data.ptr = sing->cbobject;
                 sing->evhdlr(sing->index,
                              chain->status, &chain->source,
                              chain->info, chain->ninfo,
@@ -251,6 +253,8 @@ static void progress_local_event_hdlr(pmix_status_t status,
                      * callback function to our progression function */
                     PMIX_RETAIN(chain);
                     chain->multi = multi;
+                    /* add any cbobject - the info struct for it is at the end */
+                    chain->info[chain->ninfo-1].value.data.ptr = multi->cbobject;
                     multi->evhdlr(multi->index,
                                   chain->status, &chain->source,
                                   chain->info, chain->ninfo,
@@ -277,6 +281,8 @@ static void progress_local_event_hdlr(pmix_status_t status,
             def = (pmix_default_event_t*)nxt;
             PMIX_RETAIN(chain);
             chain->def = def;
+            /* add any cbobject - the info struct for it is at the end */
+            chain->info[chain->ninfo-1].value.data.ptr = def->cbobject;
             def->evhdlr(def->index,
                         chain->status, &chain->source,
                         chain->info, chain->ninfo,
@@ -332,6 +338,8 @@ void pmix_invoke_local_event_hdlr(pmix_event_chain_t *chain)
              * callback function to our progression function */
             PMIX_RETAIN(chain);
             chain->sing = sing;
+            /* add any cbobject - the info struct for it is at the end */
+            chain->info[chain->ninfo-1].value.data.ptr = sing->cbobject;
             pmix_output_verbose(2, pmix_globals.debug_output,
                                 "[%s:%d] CALLING SINGLE EVHDLR",
                                 pmix_globals.myid.nspace, pmix_globals.myid.rank);
@@ -353,6 +361,8 @@ void pmix_invoke_local_event_hdlr(pmix_event_chain_t *chain)
                  * callback function to our progression function */
                 PMIX_RETAIN(chain);
                 chain->multi = multi;
+                /* add any cbobject - the info struct for it is at the end */
+                chain->info[chain->ninfo-1].value.data.ptr = multi->cbobject;
                 pmix_output_verbose(2, pmix_globals.debug_output,
                                     "[%s:%d] CALLING MULTI EVHDLR",
                                     pmix_globals.myid.nspace, pmix_globals.myid.rank);
@@ -375,6 +385,8 @@ void pmix_invoke_local_event_hdlr(pmix_event_chain_t *chain)
     PMIX_LIST_FOREACH(def, &pmix_globals.events.default_events, pmix_default_event_t) {
         PMIX_RETAIN(chain);
         chain->def = def;
+        /* add any cbobject - the info struct for it is at the end */
+        chain->info[chain->ninfo-1].value.data.ptr = def->cbobject;
         pmix_output_verbose(2, pmix_globals.debug_output,
                             "[%s:%d] CALLING DEFAULT EVHDLR",
                             pmix_globals.myid.nspace, pmix_globals.myid.rank);
@@ -539,6 +551,7 @@ static void sevcon(pmix_single_event_t *p)
 {
     p->name = NULL;
     p->evhdlr = NULL;
+    p->cbobject = NULL;
 }
 static void sevdes(pmix_single_event_t *p)
 {
@@ -556,6 +569,7 @@ static void mevcon(pmix_multi_event_t *p)
     p->codes = NULL;
     p->ncodes = 0;
     p->evhdlr = NULL;
+    p->cbobject = NULL;
 }
 static void mevdes(pmix_multi_event_t *p)
 {
@@ -574,6 +588,7 @@ static void devcon(pmix_default_event_t *p)
 {
     p->name = NULL;
     p->evhdlr = NULL;
+    p->cbobject = NULL;
 }
 static void devdes(pmix_default_event_t *p)
 {

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -284,6 +284,7 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
     char *name = NULL;
     pmix_list_t xfer;
     pmix_info_caddy_t *ixfer;
+    void *cbobject = NULL;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: register event_hdlr with %d infos", (int)cd->ninfo);
@@ -301,6 +302,8 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
                 name = cd->info[n].value.data.string;
             } else if (0 == strcmp(cd->info[n].key, PMIX_EVENT_ENVIRO_LEVEL)) {
                 cd->enviro = cd->info[n].value.data.flag;
+            } else if (0 == strcmp(cd->info[n].key, PMIX_EVENT_RETURN_OBJECT)) {
+                cbobject = cd->info[n].value.data.ptr;
             } else {
                 ixfer = PMIX_NEW(pmix_info_caddy_t);
                 ixfer->info = &cd->info[n];
@@ -320,6 +323,7 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
         ++pmix_globals.events.nhdlrs;
         def->index = index;
         def->evhdlr = cd->evhdlr;
+        def->cbobject = cbobject;
         rc = _add_hdlr(&pmix_globals.events.default_events, &def->super,
                        index, prepend, &xfer, cd);
         PMIX_LIST_DESTRUCT(&xfer);
@@ -348,6 +352,7 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
         index = pmix_globals.events.nhdlrs;
         sing->index = index;
         ++pmix_globals.events.nhdlrs;
+        sing->cbobject = cbobject;
         rc = _add_hdlr(&pmix_globals.events.single_events, &sing->super,
                        index, prepend, &xfer, cd);
         PMIX_LIST_DESTRUCT(&xfer);
@@ -377,6 +382,7 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
     index = pmix_globals.events.nhdlrs;
     multi->index = index;
     ++pmix_globals.events.nhdlrs;
+    multi->cbobject = cbobject;
     rc = _add_hdlr(&pmix_globals.events.multi_events, &multi->super,
                    index, prepend, &xfer, cd);
     PMIX_LIST_DESTRUCT(&xfer);


### PR DESCRIPTION
The object will be returned in one of the info structures (in fact, it is the last info struct in the array, though that is not a requirement).

Fixes #120