### PR TITLE
Fix buffer unpack hang

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -183,6 +183,8 @@ static void job_data(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
      * unpack it to maintain sequence */
     if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(buf, &nspace, &cnt, PMIX_STRING))) {
         PMIX_ERROR_LOG(rc);
+        cb->status = PMIX_ERROR;
+        cb->active = false;
         return;
     }
     /* decode it */


### PR DESCRIPTION
In case the buffer unpack failed, we have a hang in [waiting status](https://github.com/pmix/master/blob/d8def6b020dd392ed937962dcc6f4d2eb6fdb2c1/src/client/pmix_client.c#L419).