### PR TITLE
Add a new PMIX_IMMEDIATE key to indicate that PMIx_Get should check o…

### DIFF
--- a/include/pmix_common.h
+++ b/include/pmix_common.h
@@ -177,7 +177,9 @@ typedef uint32_t pmix_rank_t;
 
 /* request-related info */
 #define PMIX_COLLECT_DATA                   "pmix.collect"          // (bool) collect data and return it at the end of the operation
-#define PMIX_TIMEOUT                        "pmix.timeout"          // (int) time in sec before specified operation should time out
+#define PMIX_TIMEOUT                        "pmix.timeout"          // (int) time in sec before specified operation should time out (0 => infinite)
+#define PMIX_IMMEDIATE                      "pmix.immediate"        // (bool) specified operation should immediately return an error if requested
+                                                                    //        data cannot be found - do not request it from the host RM
 #define PMIX_WAIT                           "pmix.wait"             // (int) caller requests that the server wait until at least the specified
                                                                     //       #values are found (0 => all and is the default)
 #define PMIX_COLLECTIVE_ALGO                "pmix.calgo"            // (char*) comma-delimited list of algorithms to use for collective

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -123,9 +123,10 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
     size_t ninfo=0;
     pmix_dmdx_local_t *lcd;
     bool local;
+    bool localonly = false;
     pmix_buffer_t pbkt;
     char *data;
-    size_t sz;
+    size_t sz, n;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "recvd GET");
@@ -162,6 +163,17 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
         }
     }
 
+    /* search for directives we can deal with here */
+    for (n=0; n < ninfo; n++) {
+        if (0 == strcmp(info[n].key, PMIX_IMMEDIATE)) {
+            if (PMIX_UNDEF == info[n].value.type || info[n].value.data.flag) {
+                /* just check our own data - don't wait
+                 * or request it from someone else */
+                localonly = true;
+            }
+        }
+    }
+
     /* find the nspace object for this client */
     nptr = NULL;
     PMIX_LIST_FOREACH(ns, &pmix_globals.nspaces, pmix_nspace_t) {
@@ -179,6 +191,9 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
                         cd->peer->info->rank);
 
     if (NULL == nptr || NULL == nptr->server) {
+        if (localonly) {
+            return PMIX_ERR_NOT_FOUND;
+        }
         /* this is for an nspace we don't know about yet, so
          * record the request for data from this process and
          * give the host server a chance to tell us about it */
@@ -208,6 +223,9 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
      * we do know how many clients to expect, so first check to see if
      * all clients have been registered with us */
      if (!nptr->server->all_registered) {
+        if (localonly) {
+            return PMIX_ERR_NOT_FOUND;
+        }
         /* we cannot do anything further, so just track this request
          * for now */
         rc = create_local_tracker(nspace, rank, info, ninfo,
@@ -223,8 +241,13 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
         return rc;
     }
 
-    /* If we get here, then we don't have the data at this time. Check
-     * to see if we already have a pending request for the data - if
+    /* If we get here, then we don't have the data at this time. If
+     * the user doesn't want to look for it, then we are done */
+    if (localonly) {
+        return PMIX_ERR_NOT_FOUND;
+    }
+
+    /* Check to see if we already have a pending request for the data - if
      * we do, then we can just wait for it to arrive */
     rc = create_local_tracker(nspace, rank, info, ninfo,
                               cbfunc, cbdata, &lcd);

--- a/test/simple/simpclient.c
+++ b/test/simple/simpclient.c
@@ -94,10 +94,21 @@ int main(int argc, char **argv)
 
     /* init us */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Init failed: %d", myproc.nspace, myproc.rank, rc);
+        pmix_output(0, "Client ns %s rank %d: PMIx_Init failed: %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
         exit(rc);
     }
     pmix_output(0, "Client ns %s rank %d: Running", myproc.nspace, myproc.rank);
+
+    /* test something */
+    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_WILDCARD;
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Get failed: %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(rc);
+    }
+    PMIX_VALUE_RELEASE(val);
 
     /* register our errhandler */
     active = true;
@@ -111,7 +122,8 @@ int main(int argc, char **argv)
     (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, NULL, 0, &val))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Get universe size failed: %d", myproc.nspace, myproc.rank, rc);
+        pmix_output(0, "Client ns %s rank %d: PMIx_Get universe size failed: %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
         goto done;
     }
     nprocs = val->data.uint32;
@@ -123,7 +135,8 @@ int main(int argc, char **argv)
     value.type = PMIX_UINT32;
     value.data.uint32 = 1234;
     if (PMIX_SUCCESS != (rc = PMIx_Store_internal(&myproc, tmp, &value))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Store_internal failed: %d", myproc.nspace, myproc.rank, rc);
+        pmix_output(0, "Client ns %s rank %d: PMIx_Store_internal failed: %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
         goto done;
     }
 
@@ -132,7 +145,8 @@ int main(int argc, char **argv)
         value.type = PMIX_UINT64;
         value.data.uint64 = 1234;
         if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_LOCAL, tmp, &value))) {
-            pmix_output(0, "Client ns %s rank %d: PMIx_Put internal failed: %d", myproc.nspace, myproc.rank, rc);
+            pmix_output(0, "Client ns %s rank %d: PMIx_Put internal failed: %s",
+                        myproc.nspace, myproc.rank, PMIx_Error_string(rc));
             goto done;
         }
 
@@ -140,12 +154,14 @@ int main(int argc, char **argv)
         value.type = PMIX_STRING;
         value.data.string = "1234";
         if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_REMOTE, tmp, &value))) {
-            pmix_output(0, "Client ns %s rank %d: PMIx_Put internal failed: %d", myproc.nspace, myproc.rank, rc);
+            pmix_output(0, "Client ns %s rank %d: PMIx_Put internal failed: %s",
+                        myproc.nspace, myproc.rank, PMIx_Error_string(rc));
             goto done;
         }
 
         if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
-            pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Commit failed: %d", myproc.nspace, myproc.rank, cnt, rc);
+            pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Commit failed: %s",
+                        myproc.nspace, myproc.rank, cnt, PMIx_Error_string(rc));
             goto done;
         }
 
@@ -154,7 +170,8 @@ int main(int argc, char **argv)
         (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
         proc.rank = PMIX_RANK_WILDCARD;
         if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
-            pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Fence failed: %d", myproc.nspace, myproc.rank, cnt, rc);
+            pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Fence failed: %s",
+                        myproc.nspace, myproc.rank, cnt, PMIx_Error_string(rc));
             goto done;
         }
 
@@ -165,7 +182,8 @@ int main(int argc, char **argv)
                 proc.rank = n;
                 (void)asprintf(&tmp, "%s-%d-local-%d", myproc.nspace, n, j);
                 if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
-                    pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s failed: %d", myproc.nspace, myproc.rank, j, tmp, rc);
+                    pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s failed: %s",
+                                myproc.nspace, myproc.rank, j, tmp, PMIx_Error_string(rc));
                     continue;
                 }
                 if (PMIX_UINT64 != val->type) {
@@ -186,7 +204,8 @@ int main(int argc, char **argv)
 
                 (void)asprintf(&tmp, "%s-%d-remote-%d", proc.nspace, n, j);
                 if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
-                    pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s failed: %d", myproc.nspace, myproc.rank, j, tmp, rc);
+                    pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s failed: %s",
+                                myproc.nspace, myproc.rank, j, tmp, PMIx_Error_string(rc));
                     continue;
                 }
                 if (PMIX_STRING != val->type) {
@@ -235,7 +254,8 @@ int main(int argc, char **argv)
     /* finalize us */
     pmix_output(0, "Client ns %s rank %d: Finalizing", myproc.nspace, myproc.rank);
     if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
-        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace, myproc.rank, rc);
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
     } else {
         fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank);
     }

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -356,7 +356,7 @@ static void set_namespace(int nprocs, char *ranks, char *nspace,
     char hostname[PMIX_MAXHOSTNAMELEN];
 
     gethostname(hostname, sizeof(hostname));
-    x->ninfo = 6;
+    x->ninfo = 7;
 
     PMIX_INFO_CREATE(x->info, x->ninfo);
     (void)strncpy(x->info[0].key, PMIX_UNIV_SIZE, PMIX_MAX_KEYLEN);
@@ -384,6 +384,10 @@ static void set_namespace(int nprocs, char *ranks, char *nspace,
     (void)strncpy(x->info[5].key, PMIX_PROC_MAP, PMIX_MAX_KEYLEN);
     x->info[5].value.type = PMIX_STRING;
     x->info[5].value.data.string = ppn;
+
+    (void)strncpy(x->info[6].key, PMIX_JOB_SIZE, PMIX_MAX_KEYLEN);
+    x->info[6].value.type = PMIX_UINT32;
+    x->info[6].value.data.uint32 = nprocs;
 
     PMIx_server_register_nspace(nspace, nprocs, x->info, x->ninfo,
                                 cbfunc, x);


### PR DESCRIPTION
…nly the local client's data, and the local PMIx server's data, but not wait nor ask the RM for the data if it isn't already present. In other words, if you _know_ the data should already have been circulated, then you don't want to hang around waiting for the RM to try and find it - just return an error