### PR TITLE
First pass on reducing memory footprint

### DIFF
--- a/include/pmix_common.h
+++ b/include/pmix_common.h
@@ -603,17 +603,17 @@ typedef struct pmix_value {
         time_t time;
         pmix_status_t status;
         pmix_rank_t rank;
-        pmix_proc_t proc;
+        pmix_proc_t *proc;
         pmix_byte_object_t bo;
         pmix_persistence_t persist;
         pmix_scope_t scope;
         pmix_data_range_t range;
         pmix_proc_state_t state;
-        pmix_proc_info_t pinfo;
-        pmix_data_array_t darray;
+        pmix_proc_info_t *pinfo;
+        pmix_data_array_t *darray;
         void *ptr;
         /**** DEPRECATED ****/
-        pmix_info_array_t array;
+        pmix_info_array_t *array;
         /********************/
     } data;
 } pmix_value_t;
@@ -658,41 +658,23 @@ typedef struct pmix_value {
                 free((m)->data.bo.bytes);                                       \
             }                                                                   \
         } else if (PMIX_DATA_ARRAY == (m)->type) {                              \
-            if (PMIX_STRING == (m)->data.darray.type) {                         \
-                char **_str = (char**)(m)->data.darray.array;                   \
-                for (_n=0; _n < (m)->data.darray.size; _n++) {                  \
+            if (PMIX_STRING == (m)->data.darray->type) {                        \
+                char **_str = (char**)(m)->data.darray->array;                  \
+                for (_n=0; _n < (m)->data.darray->size; _n++) {                 \
                     if (NULL != _str[_n]) {                                     \
                         free(_str[_n]);                                         \
                     }                                                           \
                 }                                                               \
-            } else if (PMIX_PROC_INFO == (m)->data.darray.type) {               \
+            } else if (PMIX_PROC_INFO == (m)->data.darray->type) {              \
                 pmix_proc_info_t *_info =                                       \
-                            (pmix_proc_info_t*)(m)->data.darray.array;          \
-                for (_n=0; _n < (m)->data.darray.size; _n++) {                  \
+                            (pmix_proc_info_t*)(m)->data.darray->array;         \
+                for (_n=0; _n < (m)->data.darray->size; _n++) {                 \
                     PMIX_PROC_INFO_DESTRUCT(&_info[_n]);                        \
                 }                                                               \
-                /**** DEPRECATED ****/                                          \
-            } else if (PMIX_INFO_ARRAY == (m)->type) {                          \
-                pmix_info_t *_p = (pmix_info_t*)((m)->data.array.array);        \
-                for (_n=0; _n < (m)->data.array.size; _n++) {                   \
-                    if (PMIX_STRING == _p[_n].value.type) {                     \
-                        if (NULL != _p[_n].value.data.string) {                 \
-                            free(_p[_n].value.data.string);                     \
-                        }                                                       \
-                    } else if (PMIX_BYTE_OBJECT == _p[_n].value.type) {         \
-                        if (NULL != _p[_n].value.data.bo.bytes) {               \
-                            free(_p[_n].value.data.bo.bytes);                   \
-                        }                                                       \
-                    } else if (PMIX_PROC_INFO == _p[_n].value.type) {           \
-                        PMIX_PROC_INFO_DESTRUCT(&_p[_n].value.data.pinfo);      \
-                    }                                                           \
-                }                                                               \
-                free(_p);                                                       \
-                /********************/                                          \
-            } else if (PMIX_INFO == (m)->data.darray.type) {                    \
+            } else if (PMIX_INFO == (m)->data.darray->type) {                   \
                 pmix_info_t *_info =                                            \
-                            (pmix_info_t*)(m)->data.darray.array;               \
-                for (_n=0; _n < (m)->data.darray.size; _n++) {                  \
+                            (pmix_info_t*)(m)->data.darray->array;              \
+                for (_n=0; _n < (m)->data.darray->size; _n++) {                 \
                     /* cannot use info destruct as that loops back */           \
                     if (PMIX_STRING == _info[_n].value.type) {                  \
                         if (NULL != _info[_n].value.data.string) {              \
@@ -703,21 +685,39 @@ typedef struct pmix_value {
                             free(_info[_n].value.data.bo.bytes);                \
                         }                                                       \
                     } else if (PMIX_PROC_INFO == _info[_n].value.type) {        \
-                        PMIX_PROC_INFO_DESTRUCT(&_info[_n].value.data.pinfo);   \
+                        PMIX_PROC_INFO_DESTRUCT(_info[_n].value.data.pinfo);    \
                     }                                                           \
                 }                                                               \
-            } else if (PMIX_BYTE_OBJECT == (m)->data.darray.type) {             \
+            } else if (PMIX_BYTE_OBJECT == (m)->data.darray->type) {            \
                 pmix_byte_object_t *_obj =                                      \
-                            (pmix_byte_object_t*)(m)->data.darray.array;        \
-                for (_n=0; _n < (m)->data.darray.size; _n++) {                  \
+                            (pmix_byte_object_t*)(m)->data.darray->array;       \
+                for (_n=0; _n < (m)->data.darray->size; _n++) {                 \
                     if (NULL != _obj[_n].bytes) {                               \
                         free(_obj[_n].bytes);                                   \
                     }                                                           \
                 }                                                               \
             }                                                                   \
-            if (NULL != (m)->data.darray.array) {                               \
-                free((m)->data.darray.array);                                   \
+            if (NULL != (m)->data.darray->array) {                              \
+                free((m)->data.darray->array);                                  \
             }                                                                   \
+        /**** DEPRECATED ****/                                                  \
+        } else if (PMIX_INFO_ARRAY == (m)->type) {                              \
+            pmix_info_t *_p = (pmix_info_t*)((m)->data.array->array);           \
+            for (_n=0; _n < (m)->data.array->size; _n++) {                      \
+                if (PMIX_STRING == _p[_n].value.type) {                         \
+                    if (NULL != _p[_n].value.data.string) {                     \
+                        free(_p[_n].value.data.string);                         \
+                    }                                                           \
+                } else if (PMIX_BYTE_OBJECT == _p[_n].value.type) {             \
+                    if (NULL != _p[_n].value.data.bo.bytes) {                   \
+                        free(_p[_n].value.data.bo.bytes);                       \
+                    }                                                           \
+                } else if (PMIX_PROC_INFO == _p[_n].value.type) {               \
+                    PMIX_PROC_INFO_DESTRUCT(_p[_n].value.data.pinfo);           \
+                }                                                               \
+            }                                                                   \
+            free(_p);                                                           \
+        /********************/                                                  \
         }                                                                       \
     } while (0)
 

--- a/src/buffer_ops/copy.c
+++ b/src/buffer_ops/copy.c
@@ -393,23 +393,24 @@ pmix_status_t pmix_value_xfer(pmix_value_t *p, pmix_value_t *src)
         memcpy(&p->data.state, &src->data.state, sizeof(pmix_proc_state_t));
         break;
     case PMIX_PROC_INFO:
-        PMIX_PROC_INFO_CONSTRUCT(&p->data.pinfo);
-        if (NULL != src->data.pinfo.hostname) {
-            p->data.pinfo.hostname = strdup(src->data.pinfo.hostname);
+        PMIX_PROC_INFO_CREATE(p->data.pinfo, 1);
+        if (NULL != src->data.pinfo->hostname) {
+            p->data.pinfo->hostname = strdup(src->data.pinfo->hostname);
         }
-        if (NULL != src->data.pinfo.executable_name) {
-            p->data.pinfo.executable_name = strdup(src->data.pinfo.executable_name);
+        if (NULL != src->data.pinfo->executable_name) {
+            p->data.pinfo->executable_name = strdup(src->data.pinfo->executable_name);
         }
-        memcpy(&p->data.pinfo.pid, &src->data.pinfo.pid, sizeof(pid_t));
-        memcpy(&p->data.pinfo.exit_code, &src->data.pinfo.exit_code, sizeof(int));
-        memcpy(&p->data.pinfo.state, &src->data.pinfo.state, sizeof(pmix_proc_state_t));
+        memcpy(&p->data.pinfo->pid, &src->data.pinfo->pid, sizeof(pid_t));
+        memcpy(&p->data.pinfo->exit_code, &src->data.pinfo->exit_code, sizeof(int));
+        memcpy(&p->data.pinfo->state, &src->data.pinfo->state, sizeof(pmix_proc_state_t));
         break;
     case PMIX_DATA_ARRAY:
-        p->data.darray.type = src->data.darray.type;
-        p->data.darray.size = src->data.darray.size;
-        if (0 == p->data.darray.size || NULL == src->data.darray.array) {
-            p->data.darray.array = NULL;
-            p->data.darray.size = 0;
+        p->data.darray = (pmix_data_array_t*)calloc(1, sizeof(pmix_data_array_t));
+        p->data.darray->type = src->data.darray->type;
+        p->data.darray->size = src->data.darray->size;
+        if (0 == p->data.darray->size || NULL == src->data.darray->array) {
+            p->data.darray->array = NULL;
+            p->data.darray->size = 0;
             break;
         }
         /* allocate space and do the copy */
@@ -417,65 +418,65 @@ pmix_status_t pmix_value_xfer(pmix_value_t *p, pmix_value_t *src)
             case PMIX_UINT8:
             case PMIX_INT8:
             case PMIX_BYTE:
-                p->data.darray.array = (char*)malloc(src->data.darray.size);
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (char*)malloc(src->data.darray->size);
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                memcpy(p->data.darray.array, src->data.darray.array, src->data.darray.size);
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size);
                 break;
             case PMIX_UINT16:
             case PMIX_INT16:
-                p->data.darray.array = (char*)malloc(src->data.darray.size * sizeof(uint16_t));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(uint16_t));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                memcpy(p->data.darray.array, src->data.darray.array, src->data.darray.size * sizeof(uint16_t));
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(uint16_t));
                 break;
             case PMIX_UINT32:
             case PMIX_INT32:
-                p->data.darray.array = (char*)malloc(src->data.darray.size * sizeof(uint32_t));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(uint32_t));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                memcpy(p->data.darray.array, src->data.darray.array, src->data.darray.size * sizeof(uint32_t));
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(uint32_t));
                 break;
             case PMIX_UINT64:
             case PMIX_INT64:
-                p->data.darray.array = (char*)malloc(src->data.darray.size * sizeof(uint64_t));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(uint64_t));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                memcpy(p->data.darray.array, src->data.darray.array, src->data.darray.size * sizeof(uint64_t));
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(uint64_t));
                 break;
             case PMIX_BOOL:
-                p->data.darray.array = (char*)malloc(src->data.darray.size * sizeof(bool));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(bool));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                memcpy(p->data.darray.array, src->data.darray.array, src->data.darray.size * sizeof(bool));
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(bool));
                 break;
             case PMIX_SIZE:
-                p->data.darray.array = (char*)malloc(src->data.darray.size * sizeof(size_t));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(size_t));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                memcpy(p->data.darray.array, src->data.darray.array, src->data.darray.size * sizeof(size_t));
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(size_t));
                 break;
             case PMIX_PID:
-                p->data.darray.array = (char*)malloc(src->data.darray.size * sizeof(pid_t));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(pid_t));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                memcpy(p->data.darray.array, src->data.darray.array, src->data.darray.size * sizeof(pid_t));
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pid_t));
                 break;
             case PMIX_STRING:
-                p->data.darray.array = (char**)malloc(src->data.darray.size * sizeof(char*));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (char**)malloc(src->data.darray->size * sizeof(char*));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                prarray = (char**)p->data.darray.array;
-                strarray = (char**)src->data.darray.array;
-                for (n=0; n < src->data.darray.size; n++) {
+                prarray = (char**)p->data.darray->array;
+                strarray = (char**)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
                     if (NULL != strarray[n]) {
                         prarray[n] = strdup(strarray[n]);
                     }
@@ -483,76 +484,76 @@ pmix_status_t pmix_value_xfer(pmix_value_t *p, pmix_value_t *src)
                 break;
             case PMIX_INT:
             case PMIX_UINT:
-                p->data.darray.array = (char*)malloc(src->data.darray.size * sizeof(int));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(int));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                memcpy(p->data.darray.array, src->data.darray.array, src->data.darray.size * sizeof(int));
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(int));
                 break;
             case PMIX_FLOAT:
-                p->data.darray.array = (char*)malloc(src->data.darray.size * sizeof(float));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(float));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                memcpy(p->data.darray.array, src->data.darray.array, src->data.darray.size * sizeof(float));
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(float));
                 break;
             case PMIX_DOUBLE:
-                p->data.darray.array = (char*)malloc(src->data.darray.size * sizeof(double));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(double));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                memcpy(p->data.darray.array, src->data.darray.array, src->data.darray.size * sizeof(double));
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(double));
                 break;
             case PMIX_TIMEVAL:
-                p->data.darray.array = (struct timeval*)malloc(src->data.darray.size * sizeof(struct timeval));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (struct timeval*)malloc(src->data.darray->size * sizeof(struct timeval));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                memcpy(p->data.darray.array, src->data.darray.array, src->data.darray.size * sizeof(struct timeval));
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(struct timeval));
                 break;
             case PMIX_TIME:
-                p->data.darray.array = (time_t*)malloc(src->data.darray.size * sizeof(time_t));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (time_t*)malloc(src->data.darray->size * sizeof(time_t));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                memcpy(p->data.darray.array, src->data.darray.array, src->data.darray.size * sizeof(time_t));
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(time_t));
                 break;
             case PMIX_STATUS:
-                p->data.darray.array = (pmix_status_t*)malloc(src->data.darray.size * sizeof(pmix_status_t));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (pmix_status_t*)malloc(src->data.darray->size * sizeof(pmix_status_t));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                memcpy(p->data.darray.array, src->data.darray.array, src->data.darray.size * sizeof(pmix_status_t));
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_status_t));
                 break;
             case PMIX_VALUE:
-                PMIX_VALUE_CREATE(p->data.darray.array, src->data.darray.size);
-                if (NULL == p->data.darray.array) {
+                PMIX_VALUE_CREATE(p->data.darray->array, src->data.darray->size);
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                pv = (pmix_value_t*)p->data.darray.array;
-                sv = (pmix_value_t*)src->data.darray.array;
-                for (n=0; n < src->data.darray.size; n++) {
+                pv = (pmix_value_t*)p->data.darray->array;
+                sv = (pmix_value_t*)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
                     if (PMIX_SUCCESS != (rc = pmix_value_xfer(&pv[n], &sv[n]))) {
-                        PMIX_VALUE_FREE(pv, src->data.darray.size);
+                        PMIX_VALUE_FREE(pv, src->data.darray->size);
                         return rc;
                     }
                 }
                 break;
             case PMIX_PROC:
-                PMIX_PROC_CREATE(p->data.darray.array, src->data.darray.size);
-                if (NULL == p->data.darray.array) {
+                PMIX_PROC_CREATE(p->data.darray->array, src->data.darray->size);
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                memcpy(p->data.darray.array, src->data.darray.array, src->data.darray.size * sizeof(pmix_proc_t));
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_proc_t));
                 break;
             case PMIX_APP:
-                PMIX_APP_CREATE(p->data.darray.array, src->data.darray.size);
-                if (NULL == p->data.darray.array) {
+                PMIX_APP_CREATE(p->data.darray->array, src->data.darray->size);
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                pa = (pmix_app_t*)p->data.darray.array;
-                sa = (pmix_app_t*)src->data.darray.array;
-                for (n=0; n < src->data.darray.size; n++) {
+                pa = (pmix_app_t*)p->data.darray->array;
+                sa = (pmix_app_t*)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
                     if (NULL != sa[n].cmd) {
                         pa[n].cmd = strdup(sa[n].cmd);
                     }
@@ -567,7 +568,7 @@ pmix_status_t pmix_value_xfer(pmix_value_t *p, pmix_value_t *src)
                     if (0 < sa[n].ninfo && NULL != sa[n].info) {
                         PMIX_INFO_CREATE(pa[n].info, sa[n].ninfo);
                         if (NULL == pa[n].info) {
-                            PMIX_APP_FREE(pa, src->data.darray.size);
+                            PMIX_APP_FREE(pa, src->data.darray->size);
                             return PMIX_ERR_NOMEM;
                         }
                         pa[n].ninfo = sa[n].ninfo;
@@ -578,44 +579,44 @@ pmix_status_t pmix_value_xfer(pmix_value_t *p, pmix_value_t *src)
                 }
                 break;
             case PMIX_INFO:
-                PMIX_INFO_CREATE(p->data.darray.array, src->data.darray.size);
-                p1 = (pmix_info_t*)p->data.darray.array;
-                s1 = (pmix_info_t*)src->data.darray.array;
-                for (n=0; n < src->data.darray.size; n++) {
+                PMIX_INFO_CREATE(p->data.darray->array, src->data.darray->size);
+                p1 = (pmix_info_t*)p->data.darray->array;
+                s1 = (pmix_info_t*)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
                     PMIX_INFO_LOAD(&p1[n], s1[n].key, &s1[n].value.data.flag, s1[n].value.type);
                 }
                 break;
             case PMIX_PDATA:
-                PMIX_PDATA_CREATE(p->data.darray.array, src->data.darray.size);
-                if (NULL == p->data.darray.array) {
+                PMIX_PDATA_CREATE(p->data.darray->array, src->data.darray->size);
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                pd = (pmix_pdata_t*)p->data.darray.array;
-                sd = (pmix_pdata_t*)src->data.darray.array;
-                for (n=0; n < src->data.darray.size; n++) {
+                pd = (pmix_pdata_t*)p->data.darray->array;
+                sd = (pmix_pdata_t*)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
                     PMIX_PDATA_LOAD(&pd[n], &sd[n].proc, sd[n].key, &sd[n].value.data.flag, sd[n].value.type);
                 }
                 break;
             case PMIX_BUFFER:
-                p->data.darray.array = (pmix_buffer_t*)malloc(src->data.darray.size * sizeof(pmix_buffer_t));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (pmix_buffer_t*)malloc(src->data.darray->size * sizeof(pmix_buffer_t));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                pb = (pmix_buffer_t*)p->data.darray.array;
-                sb = (pmix_buffer_t*)src->data.darray.array;
-                for (n=0; n < src->data.darray.size; n++) {
+                pb = (pmix_buffer_t*)p->data.darray->array;
+                sb = (pmix_buffer_t*)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
                     PMIX_CONSTRUCT(&pb[n], pmix_buffer_t);
                     pmix_bfrop.copy_payload(&pb[n], &sb[n]);
                 }
                 break;
             case PMIX_BYTE_OBJECT:
-                p->data.darray.array = (pmix_byte_object_t*)malloc(src->data.darray.size * sizeof(pmix_byte_object_t));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (pmix_byte_object_t*)malloc(src->data.darray->size * sizeof(pmix_byte_object_t));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                pbo = (pmix_byte_object_t*)p->data.darray.array;
-                sbo = (pmix_byte_object_t*)src->data.darray.array;
-                for (n=0; n < src->data.darray.size; n++) {
+                pbo = (pmix_byte_object_t*)p->data.darray->array;
+                sbo = (pmix_byte_object_t*)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
                     if (NULL != sbo[n].bytes && 0 < sbo[n].size) {
                         pbo[n].size = sbo[n].size;
                         pbo[n].bytes = (char*)malloc(pbo[n].size);
@@ -627,20 +628,20 @@ pmix_status_t pmix_value_xfer(pmix_value_t *p, pmix_value_t *src)
                 }
                 break;
             case PMIX_KVAL:
-                p->data.darray.array = (pmix_kval_t*)calloc(src->data.darray.size , sizeof(pmix_kval_t));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (pmix_kval_t*)calloc(src->data.darray->size , sizeof(pmix_kval_t));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                pk = (pmix_kval_t*)p->data.darray.array;
-                sk = (pmix_kval_t*)src->data.darray.array;
-                for (n=0; n < src->data.darray.size; n++) {
+                pk = (pmix_kval_t*)p->data.darray->array;
+                sk = (pmix_kval_t*)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
                     if (NULL != sk[n].key) {
                         pk[n].key = strdup(sk[n].key);
                     }
                     if (NULL != sk[n].value) {
                         PMIX_VALUE_CREATE(pk[n].value, 1);
                         if (NULL == pk[n].value) {
-                            free(p->data.darray.array);
+                            free(p->data.darray->array);
                             return PMIX_ERR_NOMEM;
                         }
                         if (PMIX_SUCCESS != (rc = pmix_value_xfer(pk[n].value, sk[n].value))) {
@@ -650,13 +651,13 @@ pmix_status_t pmix_value_xfer(pmix_value_t *p, pmix_value_t *src)
                 }
                 break;
             case PMIX_MODEX:
-                PMIX_MODEX_CREATE(p->data.darray.array, src->data.darray.size);
-                if (NULL == p->data.darray.array) {
+                PMIX_MODEX_CREATE(p->data.darray->array, src->data.darray->size);
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                pm = (pmix_modex_data_t*)p->data.darray.array;
-                sm = (pmix_modex_data_t*)src->data.darray.array;
-                for (n=0; n < src->data.darray.size; n++) {
+                pm = (pmix_modex_data_t*)p->data.darray->array;
+                sm = (pmix_modex_data_t*)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
                     memcpy(&pm[n], &sm[n], sizeof(pmix_modex_data_t));
                     if (NULL != sm[n].blob && 0 < sm[n].size) {
                         pm[n].blob = (uint8_t*)malloc(sm[n].size);
@@ -672,59 +673,59 @@ pmix_status_t pmix_value_xfer(pmix_value_t *p, pmix_value_t *src)
                 }
                 break;
             case PMIX_PERSIST:
-                p->data.darray.array = (pmix_persistence_t*)malloc(src->data.darray.size * sizeof(pmix_persistence_t));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (pmix_persistence_t*)malloc(src->data.darray->size * sizeof(pmix_persistence_t));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                memcpy(p->data.darray.array, src->data.darray.array, src->data.darray.size * sizeof(pmix_persistence_t));
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_persistence_t));
                 break;
             case PMIX_POINTER:
-                p->data.darray.array = (char**)malloc(src->data.darray.size * sizeof(char*));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (char**)malloc(src->data.darray->size * sizeof(char*));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                prarray = (char**)p->data.darray.array;
-                strarray = (char**)src->data.darray.array;
-                for (n=0; n < src->data.darray.size; n++) {
+                prarray = (char**)p->data.darray->array;
+                strarray = (char**)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
                     prarray[n] = strarray[n];
                 }
                 break;
             case PMIX_SCOPE:
-                p->data.darray.array = (pmix_scope_t*)malloc(src->data.darray.size * sizeof(pmix_scope_t));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (pmix_scope_t*)malloc(src->data.darray->size * sizeof(pmix_scope_t));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                memcpy(p->data.darray.array, src->data.darray.array, src->data.darray.size * sizeof(pmix_scope_t));
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_scope_t));
                 break;
             case PMIX_DATA_RANGE:
-                p->data.darray.array = (pmix_data_range_t*)malloc(src->data.darray.size * sizeof(pmix_data_range_t));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (pmix_data_range_t*)malloc(src->data.darray->size * sizeof(pmix_data_range_t));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                memcpy(p->data.darray.array, src->data.darray.array, src->data.darray.size * sizeof(pmix_data_range_t));
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_data_range_t));
                 break;
             case PMIX_COMMAND:
-                p->data.darray.array = (pmix_cmd_t*)malloc(src->data.darray.size * sizeof(pmix_cmd_t));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (pmix_cmd_t*)malloc(src->data.darray->size * sizeof(pmix_cmd_t));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                memcpy(p->data.darray.array, src->data.darray.array, src->data.darray.size * sizeof(pmix_cmd_t));
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_cmd_t));
                 break;
             case PMIX_INFO_DIRECTIVES:
-                p->data.darray.array = (pmix_info_directives_t*)malloc(src->data.darray.size * sizeof(pmix_info_directives_t));
-                if (NULL == p->data.darray.array) {
+                p->data.darray->array = (pmix_info_directives_t*)malloc(src->data.darray->size * sizeof(pmix_info_directives_t));
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                memcpy(p->data.darray.array, src->data.darray.array, src->data.darray.size * sizeof(pmix_info_directives_t));
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_info_directives_t));
                 break;
             case PMIX_PROC_INFO:
-                PMIX_PROC_INFO_CREATE(p->data.darray.array, src->data.darray.size);
-                if (NULL == p->data.darray.array) {
+                PMIX_PROC_INFO_CREATE(p->data.darray->array, src->data.darray->size);
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                pi = (pmix_proc_info_t*)p->data.darray.array;
-                si = (pmix_proc_info_t*)src->data.darray.array;
-                for (n=0; n < src->data.darray.size; n++) {
+                pi = (pmix_proc_info_t*)p->data.darray->array;
+                si = (pmix_proc_info_t*)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
                     memcpy(&pi[n].proc, &si[n].proc, sizeof(pmix_proc_t));
                     if (NULL != si[n].hostname) {
                         pi[n].hostname = strdup(si[n].hostname);
@@ -744,20 +745,20 @@ pmix_status_t pmix_value_xfer(pmix_value_t *p, pmix_value_t *src)
             case PMIX_DATA_ARRAY:
                 return PMIX_ERR_NOT_SUPPORTED;  // don't support iterative arrays
             case PMIX_QUERY:
-                PMIX_QUERY_CREATE(p->data.darray.array, src->data.darray.size);
-                if (NULL == p->data.darray.array) {
+                PMIX_QUERY_CREATE(p->data.darray->array, src->data.darray->size);
+                if (NULL == p->data.darray->array) {
                     return PMIX_ERR_NOMEM;
                 }
-                pq = (pmix_query_t*)p->data.darray.array;
-                sq = (pmix_query_t*)src->data.darray.array;
-                for (n=0; n < src->data.darray.size; n++) {
+                pq = (pmix_query_t*)p->data.darray->array;
+                sq = (pmix_query_t*)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
                     if (NULL != sq[n].keys) {
                         pq[n].keys = pmix_argv_copy(sq[n].keys);
                     }
                     if (NULL != sq[n].qualifiers && 0 < sq[n].nqual) {
                         PMIX_INFO_CREATE(pq[n].qualifiers, sq[n].nqual);
                         if (NULL == pq[n].qualifiers) {
-                            PMIX_QUERY_FREE(pq, src->data.darray.size);
+                            PMIX_QUERY_FREE(pq, src->data.darray->size);
                             return PMIX_ERR_NOMEM;
                         }
                         for (m=0; m < sq[n].nqual; m++) {
@@ -779,15 +780,15 @@ pmix_status_t pmix_value_xfer(pmix_value_t *p, pmix_value_t *src)
         break;
     /**** DEPRECATED ****/
     case PMIX_INFO_ARRAY:
-        p->data.array.size = src->data.array.size;
-        if (0 < src->data.array.size) {
-            p->data.array.array = (pmix_info_t*)malloc(src->data.array.size * sizeof(pmix_info_t));
-            if (NULL == p->data.array.array) {
+        p->data.array->size = src->data.array->size;
+        if (0 < src->data.array->size) {
+            p->data.array->array = (pmix_info_t*)malloc(src->data.array->size * sizeof(pmix_info_t));
+            if (NULL == p->data.array->array) {
                 return PMIX_ERR_NOMEM;
             }
-            p1 = (pmix_info_t*)p->data.array.array;
-            s1 = (pmix_info_t*)src->data.array.array;
-            for (n=0; n < src->data.darray.size; n++) {
+            p1 = (pmix_info_t*)p->data.array->array;
+            s1 = (pmix_info_t*)src->data.array->array;
+            for (n=0; n < src->data.darray->size; n++) {
                 PMIX_INFO_LOAD(&p1[n], s1[n].key, &s1[n].value.data.flag, s1[n].value.type);
             }
         }

--- a/src/buffer_ops/pack.c
+++ b/src/buffer_ops/pack.c
@@ -540,7 +540,7 @@ static pmix_status_t pack_val(pmix_buffer_t *buffer,
             }
             break;
         case PMIX_PROC:
-            if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_buffer(buffer, &p->data.proc, 1, PMIX_PROC))) {
+            if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_buffer(buffer, p->data.proc, 1, PMIX_PROC))) {
                 return ret;
             }
             break;
@@ -575,23 +575,23 @@ static pmix_status_t pack_val(pmix_buffer_t *buffer,
             }
             break;
         case PMIX_PROC_INFO:
-            if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_buffer(buffer, &p->data.pinfo, 1, PMIX_PROC_INFO))) {
+            if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_buffer(buffer, p->data.pinfo, 1, PMIX_PROC_INFO))) {
                 return ret;
             }
             break;
         case PMIX_DATA_ARRAY:
-            if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_buffer(buffer, &p->data.darray, 1, PMIX_DATA_ARRAY))) {
+            if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_buffer(buffer, p->data.darray, 1, PMIX_DATA_ARRAY))) {
                 return ret;
             }
             break;
         case PMIX_QUERY:
-            if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_buffer(buffer, &p->data.darray, 1, PMIX_QUERY))) {
+            if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_buffer(buffer, p->data.darray, 1, PMIX_QUERY))) {
                 return ret;
             }
             break;
         /**** DEPRECATED ****/
         case PMIX_INFO_ARRAY:
-            if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_buffer(buffer, &p->data.array, 1, PMIX_INFO_ARRAY))) {
+            if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_buffer(buffer, p->data.array, 1, PMIX_INFO_ARRAY))) {
                 return ret;
             }
             break;

--- a/src/buffer_ops/print.c
+++ b/src/buffer_ops/print.c
@@ -865,26 +865,44 @@ pmix_status_t pmix_bfrop_print_status(char **output, char *prefix,
                       PMIx_Error_string(src->data.status));
         break;
         case PMIX_PROC:
+        if (NULL == src->data.proc) {
+            rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PROC\tNULL", prefx);
+        } else {
+            rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PROC\t%s:%lu",
+                          prefx, src->data.proc->nspace, (unsigned long)src->data.proc->rank);
+        }
+        break;
         case PMIX_BYTE_OBJECT:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: BYTE_OBJECT\tSIZE: %ld",
+                      prefx, (long)src->data.bo.size);
+        break;
         case PMIX_PERSIST:
         rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PERSIST\tValue: %d",
                       prefx, (int)src->data.persist);
         break;
         case PMIX_SCOPE:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PERSIST\tValue: %d",
-                      prefx, (int)src->data.persist);
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_SCOPE\tValue: %d",
+                      prefx, (int)src->data.scope);
         break;
         case PMIX_DATA_RANGE:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PERSIST\tValue: %d",
-                      prefx, (int)src->data.persist);
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_DATA_RANGE\tValue: %d",
+                      prefx, (int)src->data.range);
         break;
         case PMIX_PROC_STATE:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_STATE\tValue: %d",
+                      prefx, (int)src->data.state);
+        break;
         case PMIX_PROC_INFO:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PROC_INFO\tValue: %s:%lu",
+                      prefx, src->data.proc->nspace, (unsigned long)src->data.proc->rank);
+        break;
         case PMIX_DATA_ARRAY:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: DATA_ARRAY\tARRAY SIZE: %ld",
+                      prefx, (long)src->data.darray->size);
         /**** DEPRECATED ****/
         case PMIX_INFO_ARRAY:
         rc = asprintf(output, "%sPMIX_VALUE: Data type: INFO_ARRAY\tARRAY SIZE: %ld",
-                      prefx, (long)src->data.array.size);
+                      prefx, (long)src->data.array->size);
         break;
         /********************/
         default:

--- a/src/buffer_ops/unpack.c
+++ b/src/buffer_ops/unpack.c
@@ -631,7 +631,7 @@ pmix_status_t pmix_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
             }
             break;
         case PMIX_PROC:
-            if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_buffer(buffer, &val->data.proc, &m, PMIX_PROC))) {
+            if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_buffer(buffer, val->data.proc, &m, PMIX_PROC))) {
                 return ret;
             }
             break;
@@ -666,23 +666,23 @@ pmix_status_t pmix_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
             }
             break;
         case PMIX_PROC_INFO:
-            if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_buffer(buffer, &val->data.pinfo, &m, PMIX_PROC_INFO))) {
+            if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_buffer(buffer, val->data.pinfo, &m, PMIX_PROC_INFO))) {
                 return ret;
             }
             break;
         case PMIX_DATA_ARRAY:
-            if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_buffer(buffer, &val->data.darray, &m, PMIX_DATA_ARRAY))) {
+            if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_buffer(buffer, val->data.darray, &m, PMIX_DATA_ARRAY))) {
                 return ret;
             }
             break;
         case PMIX_QUERY:
-            if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_buffer(buffer, &val->data.darray, &m, PMIX_QUERY))) {
+            if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_buffer(buffer, val->data.darray, &m, PMIX_QUERY))) {
                 return ret;
             }
             break;
         /**** DEPRECATED ****/
         case PMIX_INFO_ARRAY:
-            if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_buffer(buffer, &val->data.array, &m, PMIX_INFO_ARRAY))) {
+            if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_buffer(buffer, val->data.array, &m, PMIX_INFO_ARRAY))) {
                 return ret;
             }
             break;

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -413,11 +413,11 @@ static pmix_status_t process_val(pmix_value_t *val,
     }
     /* save the results */
     if (PMIX_DATA_ARRAY == val->type) {
-        info = (pmix_info_t*)val->data.darray.array;
-        nsize = val->data.darray.size;
+        info = (pmix_info_t*)val->data.darray->array;
+        nsize = val->data.darray->size;
     } else {
-        info = (pmix_info_t*)val->data.array.array;
-        nsize = val->data.array.size;
+        info = (pmix_info_t*)val->data.array->array;
+        nsize = val->data.array->size;
     }
     nvals = 0;
     for (n=0; n < nsize; n++) {
@@ -427,11 +427,11 @@ static pmix_status_t process_val(pmix_value_t *val,
         ++nvals;
     }
     if (PMIX_DATA_ARRAY == val->type) {
-        val->data.darray.array = NULL;  // protect the data
-        val->data.darray.size = 0;
+        val->data.darray->array = NULL;  // protect the data
+        val->data.darray->size = 0;
     } else {
-        val->data.array.array = NULL;
-        val->data.array.size = 0;
+        val->data.array->array = NULL;
+        val->data.array->size = 0;
     }
     /* increment the number of values */
     (*num_vals) += nvals;
@@ -530,10 +530,10 @@ static void _getnbfn(int fd, short flags, void *cbdata)
         /* now let's package up the results */
         PMIX_VALUE_CREATE(val, 1);
         val->type = PMIX_DATA_ARRAY;
-        val->data.darray.type = PMIX_INFO;
-        val->data.darray.size = nvals;
+        val->data.darray->type = PMIX_INFO;
+        val->data.darray->size = nvals;
         PMIX_INFO_CREATE(iptr, nvals);
-        val->data.darray.array = (void*)iptr;
+        val->data.darray->array = (void*)iptr;
         for (n=0; n < (size_t)results.size && n < nvals; n++) {
             if (NULL != (info = (pmix_info_t*)pmix_pointer_array_get_item(&results, n))) {
                 (void)strncpy(iptr[n].key, info->key, PMIX_MAX_KEYLEN);

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -380,8 +380,12 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
                 free(pmix_pid);
                 return PMIX_ERR_INVALID_LENGTH;
             }
+            pmix_output_verbose(2, pmix_globals.debug_output,
+                                "%s:%d dropping system tool at %s",
+                                pmix_globals.myid.nspace,
+                                pmix_globals.myid.rank, pmix_pid);
             /* create the listener for this point */
-            pmix_listener_t *tl = PMIX_NEW(pmix_listener_t);
+            tl = PMIX_NEW(pmix_listener_t);
             tl -> address.sun_family = AF_UNIX;
             tl->protocol = PMIX_PROTOCOL_TOOL;
             snprintf(tl->address.sun_path, sizeof(tl->address.sun_path) - 1, "%s", pmix_pid);
@@ -409,6 +413,10 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
                 free(pmix_pid);
                 return PMIX_ERR_INVALID_LENGTH;
             }
+            pmix_output_verbose(2, pmix_globals.debug_output,
+                                "%s:%d dropping session tool at %s",
+                                pmix_globals.myid.nspace,
+                                pmix_globals.myid.rank, pmix_pid);
             /* create the listener for this point */
             tl = PMIX_NEW(pmix_listener_t);
             tl -> address.sun_family = AF_UNIX;
@@ -650,12 +658,12 @@ static void _register_nspace(int sd, short args, void *cbdata)
         } else if (0 == strcmp(cd->info[i].key, PMIX_PROC_DATA)) {
             /* an array of data pertaining to a specific proc */
             if (PMIX_DATA_ARRAY != cd->info[i].value.type ||
-                PMIX_INFO != cd->info[i].value.data.darray.type) {
+                PMIX_INFO != cd->info[i].value.data.darray->type) {
                 PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
                 goto release;
             }
-            size = cd->info[i].value.data.darray.size;
-            iptr = (pmix_info_t*)cd->info[i].value.data.darray.array;
+            size = cd->info[i].value.data.darray->size;
+            iptr = (pmix_info_t*)cd->info[i].value.data.darray->array;
             PMIX_CONSTRUCT(&buf2, pmix_buffer_t);
             /* first element of the array must be the rank */
             if (0 != strcmp(iptr[0].key, PMIX_RANK)) {

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -49,6 +49,7 @@
 #endif  /* HAVE_DIRENT_H */
 
 #include PMIX_EVENT_HEADER
+#include PMIX_EVENT2_THREAD_HEADER
 
 #if PMIX_CC_USE_PRAGMA_IDENT
 #pragma ident PMIX_VERSION
@@ -299,6 +300,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
             }
             /* otherwise, this isn't a fatal error - reset the addr */
             memset(&address, 0, sizeof(struct sockaddr_un));
+            address.sun_family = AF_UNIX;
             connection_defined = false;
         } else {
             /* connect to this server */
@@ -370,6 +372,10 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     pmix_bfrop_open();
     pmix_usock_init(pmix_tool_notify_recv);
     pmix_sec_init();
+
+
+    /* tell the event library we need thread support */
+    pmix_event_use_threads();
 
     if (!pmix_globals.external_evbase) {
         /* create an event base and progress thread for us */
@@ -836,7 +842,8 @@ static pmix_status_t usock_connect(struct sockaddr_un *addr, int *fd)
     int retries = 0;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
-                        "usock_peer_try_connect: attempting to connect to server");
+                        "usock_peer_try_connect: attempting to connect to server at %s",
+                        addr->sun_path);
 
     addrlen = sizeof(struct sockaddr_un);
     while (retries < PMIX_MAX_RETRIES) {


### PR DESCRIPTION
Convert the larger objects in pmix_value_t to pointers to those objects, thus reducing the overall size of pmix_value_t to roughly 8 bytes.

Refs #129 