### PR TITLE
Fix dstore bus error on sparc64

### DIFF
--- a/src/dstore/pmix_esh.c
+++ b/src/dstore/pmix_esh.c
@@ -499,11 +499,13 @@ int _esh_fetch(const char *nspace, pmix_rank_t rank, const char *key, pmix_value
                             "%s:%d:%s: for rank %s:%u, skip %s region",
                             __FILE__, __LINE__, __func__, nspace, cur_rank, ESH_REGION_INVALIDATED));
                 /*skip it */
-                size_t size = *(size_t *)(addr + PMIX_MAX_KEYLEN + 1);
+                size_t size;
+                memcpy(&size, addr + PMIX_MAX_KEYLEN + 1, sizeof(size_t));
                 /* go to next item, updating address */
                 addr += KVAL_SIZE(size);
             } else if (0 == strncmp((const char *)addr, ESH_REGION_EXTENSION, PMIX_MAX_KEYLEN+1)) {
-                size_t offset = *(size_t *)(addr + PMIX_MAX_KEYLEN + 1 + sizeof(size_t));
+                size_t offset;
+                memcpy(&offset, addr + PMIX_MAX_KEYLEN + 1 + sizeof(size_t), sizeof(size_t));
                 PMIX_OUTPUT_VERBOSE((10, pmix_globals.debug_output,
                             "%s:%d:%s: for rank %s:%u, reached %s with %lu value",
                             __FILE__, __LINE__, __func__, nspace, cur_rank, ESH_REGION_EXTENSION, offset));
@@ -528,7 +530,8 @@ int _esh_fetch(const char *nspace, pmix_rank_t rank, const char *key, pmix_value
                             "%s:%d:%s: for rank %s:%u, found target key %s",
                             __FILE__, __LINE__, __func__, nspace, cur_rank, key));
                 /* target key is found, get value */
-                size_t size = *(size_t *)(addr + PMIX_MAX_KEYLEN + 1);
+                size_t size;
+                memcpy(&size, addr + PMIX_MAX_KEYLEN + 1, sizeof(size_t));
                 addr += PMIX_MAX_KEYLEN + 1 + sizeof(size_t);
                 PMIX_CONSTRUCT(&buffer, pmix_buffer_t);
                 PMIX_LOAD_BUFFER(&buffer, addr, size);
@@ -548,7 +551,8 @@ int _esh_fetch(const char *nspace, pmix_rank_t rank, const char *key, pmix_value
             } else {
                 char ckey[PMIX_MAX_KEYLEN+1] = {0};
                 strncpy(ckey, (const char *)addr, PMIX_MAX_KEYLEN+1);
-                size_t size = *(size_t *)(addr + PMIX_MAX_KEYLEN + 1);
+                size_t size;
+                memcpy(&size, addr + PMIX_MAX_KEYLEN + 1, sizeof(size_t));
                 PMIX_OUTPUT_VERBOSE((10, pmix_globals.debug_output,
                             "%s:%d:%s: for rank %s:%u, skip key %s look for key %s", __FILE__, __LINE__, __func__, nspace, cur_rank, ckey, key));
                 /* go to next item, updating address */
@@ -1366,7 +1370,7 @@ static int pmix_sm_store(ns_track_elem_t *ns_info, pmix_rank_t rank, pmix_kval_t
              * extension slot which has key = EXTENSION_SLOT and a size_t value for offset to next data address for this process.
              */
             if (0 == strncmp((const char *)addr, ESH_REGION_EXTENSION, PMIX_MAX_KEYLEN+1)) {
-                offset = *(size_t *)(addr + PMIX_MAX_KEYLEN + 1 + sizeof(size_t));
+                memcpy(&offset, addr + PMIX_MAX_KEYLEN + 1 + sizeof(size_t), sizeof(size_t));
                 if (0 < offset) {
                     PMIX_OUTPUT_VERBOSE((10, pmix_globals.debug_output,
                                 "%s:%d:%s: for rank %u, replace flag %d %s is filled with %lu value",
@@ -1386,7 +1390,8 @@ static int pmix_sm_store(ns_track_elem_t *ns_info, pmix_rank_t rank, pmix_kval_t
                             "%s:%d:%s: for rank %u, replace flag %d found target key %s",
                             __FILE__, __LINE__, __func__, rank, data_exist, kval->key));
                 /* target key is found, compare value sizes */
-                size_t cur_size = *(size_t *)(addr + PMIX_MAX_KEYLEN + 1);
+                size_t cur_size;
+                memcpy(&cur_size, addr + PMIX_MAX_KEYLEN + 1, sizeof(size_t));
                 if (cur_size != size) {
                 //if (1) { /* if we want to test replacing values for existing keys. */
                     /* invalidate current value and store another one at the end of data region. */
@@ -1424,7 +1429,8 @@ static int pmix_sm_store(ns_track_elem_t *ns_info, pmix_rank_t rank, pmix_kval_t
                     /* count only valid items */
                     kval_cnt--;
                 }
-                size_t size = *(size_t *)(addr + PMIX_MAX_KEYLEN + 1);
+                size_t size;
+                memcpy(&size, addr + PMIX_MAX_KEYLEN + 1, sizeof(size_t));
                 /* go to next item, updating address */
                 addr += KVAL_SIZE(size);
             }

--- a/src/dstore/pmix_esh.h
+++ b/src/dstore/pmix_esh.h
@@ -33,7 +33,7 @@ typedef enum {
 
 /* initial segment format:
  * size_t num_elems;
- * int full; //indicate to client that it needs to attach to the next segment
+ * size_t full; //indicate to client that it needs to attach to the next segment
  * ns_seg_info_t ns_seg_info[max_ns_num];
  */
 


### PR DESCRIPTION
Recent dstore code causes a bus error on sparc64 because sparc64 needs 64-bit alignment when accessing 64-bit value but elements in dstore initial segments and data segments are not (necessarily) aligned.

Could someone review? I ran a simple MPI program to confirm the fix.

For initial segments, I changed the type of `full` to `size_t` from `int`. Another solution is to use `PMIX_ALIGN`. If you prefer `PMIX_ALIGN`, I'll update this PR.
