### PR TITLE
Remove stale usock files if bind() failed.

### DIFF
--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -213,8 +213,11 @@ static pmix_status_t initialize_server_base(pmix_server_module_t *module)
     }
 
     /* for now, just setup the v1.1 series rendezvous point
-     * we use the pid to reduce collisions */
-    if (0 > asprintf(&pmix_pid, "%s/pmix-%d", tdir, mypid)) {
+     * - use userid to avoid situation where user with other UID but same PID 
+     *   has created the usock and terminate abnormally and we have no way to
+     *   remove the file
+     * - use the pid to reduce collisions */
+    if (0 > asprintf(&pmix_pid, "%s/pmix-%d.%d", tdir, getuid(), mypid)) {
         return PMIX_ERR_NOMEM;
     }
 


### PR DESCRIPTION
We see sporadic MTT failures with the following error
```
[cn1:10888] [[44817,0],0] ORTE_ERROR_LOG: Error in file orted/pmix/pmix_server.c at line 254
[cn1:10888] [[44817,0],0] ORTE_ERROR_LOG: Error in file ess_hnp_module.c at line 656--------------------------------------------------------------------------
It looks like orte_init failed for some reason; your parallel process is
likely to abort.  There are many reasons that a parallel process can
fail during orte_init; some of which are due to configuration or
environment problems.  This failure appears to be an internal failure;
here's some additional information (which may only be relevant to an
Open MPI developer):

  pmix server init failed
  --> Returned value Error (-1) instead of ORTE_SUCCESS
--------------------------------------------------------------------------
src/server/pmix_server_listener.c:92 bind() failed+ rc=213
+ exit 213
```

Looking into the /tmp directory I see lot's of pmix usock files and given that PID conflict can appear sometimes this may explain sporadic nature of MTT failures.

Also this PR makes bind failures more verbosive - errno is printed out helping to locate the reason if my original guess is incorrect.

I'm also investigating possible reasons of usock leftower's.