### PR TITLE
client: fix PMIx_Finalize() sequence

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -500,12 +500,12 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
                              "pmix:client finalize sync received");
      }
 
+     PMIX_DESTRUCT(&pmix_client_globals.myserver);
      if (!pmix_globals.external_evbase) {
          pmix_stop_progress_thread(pmix_globals.evbase);
      }
 
      pmix_usock_finalize();
-     PMIX_DESTRUCT(&pmix_client_globals.myserver);
      PMIX_LIST_DESTRUCT(&pmix_client_globals.pending_requests);
 
      if (0 <= pmix_client_globals.myserver.sd) {


### PR DESCRIPTION
pmix_progress_thread_finalize() invokes libevent event_base_free,
so all libevent stuff cannot be used after.
Hence, pmix_client_globals.myserver must be PMIX_DESTRUCT'ed
before invoking pmix_progress_thread_finalize()