### PR TITLE
v2.x: misc fixes to get pmix build on Solaris

### DIFF
--- a/examples/dynamic.c
+++ b/examples/dynamic.c
@@ -15,6 +15,8 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -46,7 +48,7 @@ int main(int argc, char **argv)
     uint32_t nprocs;
     char nsp2[PMIX_MAX_NSLEN+1];
     pmix_app_t *app;
-    char hostname[MAXHOSTNAMELEN], dir[1024];
+    char hostname[1024], dir[1024];
     pmix_proc_t *peers;
     size_t npeers, ntmp=0;
     char *nodelist;

--- a/test/utils.c
+++ b/test/utils.c
@@ -2,6 +2,8 @@
  * Copyright (c) 2015      Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -234,9 +236,7 @@ int launch_clients(int num_procs, char *binary, char *** client_env, char ***bas
         if (cli_info[counter].pid == 0) {
             if( !TEST_VERBOSE_GET() ){
                 // Hide clients stdout
-                // TODO: on some systems stdout is a constant, address this
-                fclose(stdout);
-                stdout = fopen("/dev/null","w");
+                freopen("/dev/null","w", stdout);
             }
             execve(binary, client_argv, *client_env);
             /* Does not return */


### PR DESCRIPTION
- replace MAXHOSTNAMELEN with hardcoded 1024.
  unlike Linux, Solaris #define MAXHOSTNAMELEN in <netdb.h>,
  so use a hard coded value to keep the test simpl
- stdout cannot be assigned on Solaris, so use freopen instead

(cherry picked from commit pmix/master@a63f6e53f4f1f0851316875b3f21f0a25cadfa65)
