### PR TITLE
client: invoke pmix_progress_thread_init() once

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -351,17 +351,6 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
     }
 #endif /* PMIX_ENABLE_DSTORE */
 
-    if (!pmix_globals.external_evbase) {
-        /* tell the event library we need thread support */
-        pmix_event_use_threads();
-
-        /* create an event base and progress thread for us */
-        if (NULL == (pmix_globals.evbase = pmix_progress_thread_init(NULL))) {
-            return -1;
-
-        }
-    }
-
     /* setup an object to track server connection */
     PMIX_CONSTRUCT(&cb, pmix_cb_t);
     cb.active = true;


### PR DESCRIPTION
pmix_progress_thread_init() is already (indirectly) invoked
(by pmix_rte_init()) so there is no need to call it again