### PR TITLE
Daves new get changes 

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -309,6 +309,11 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
                 }
                 free(nspace);
                 pmix_client_process_nspace_blob(cb->nspace, bptr);
+
+                /* Check if the key is in this blob */
+
+                pmix_hash_fetch(&nptr->internal, cb->rank, cb->key, &val);
+		
             } else {
                 cnt = 1;
                 cur_kval = PMIX_NEW(pmix_kval_t);

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1633,6 +1633,7 @@ static void _spcb(int sd, short args, void *cbdata)
     pmix_nspace_t *nptr, *ns;
     pmix_buffer_t *reply;
     pmix_status_t rc;
+    char          *msg;
 
     /* setup the reply with the returned status */
     reply = PMIX_NEW(pmix_buffer_t);
@@ -1653,8 +1654,11 @@ static void _spcb(int sd, short args, void *cbdata)
             }
         }
         if (NULL == nptr) {
-            /* shouldn't happen */
-            PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
+            /* This can happen if there are no processes from this 
+             * namespace running on this host.  In this case just 
+             * pack the name of the namespace because we need that. */
+            msg = cd->nspace;
+            pmix_bfrop.pack(reply, &msg, 1, PMIX_STRING);
         } else {
             pmix_bfrop.copy_payload(reply, &nptr->server->job_info);
         }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1112,6 +1112,19 @@ static void _dmodex_req(int sd, short args, void *cbdata)
         return;
     }
 
+    /* They are asking for job level data for this process */
+    if (cd->proc.rank == PMIX_RANK_WILDCARD) {
+       
+       data = nptr->server->job_info.base_ptr;
+       sz = nptr->server->job_info.bytes_used;
+
+       /* execute the callback */
+       cd->cbfunc(PMIX_SUCCESS, data, sz, cd->cbdata);
+       cd->active = false;
+           
+       return;
+    }
+
     /* see if we have this peer in our list */
     info = NULL;
     PMIX_LIST_FOREACH(iptr, &nptr->server->ranks, pmix_rank_info_t) {

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -199,7 +199,15 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
          * give the host server a chance to tell us about it */
         rc = create_local_tracker(nspace, rank, info, ninfo,
                                   cbfunc, cbdata, &lcd);
-        return rc;
+        /*
+         * Its possible there are no local processes on this 
+         * host, so lets ask for this explicitly.  There can
+         * be a timing issue here if this information shows 
+         * up on its own, but I believe we handle it ok.  */
+        if( NULL != pmix_host_server.direct_modex ){
+                pmix_host_server.direct_modex(&lcd->proc, info, ninfo, dmdx_cbfunc, lcd);
+        }
+        return (rc == PMIX_ERR_NOT_FOUND ? PMIX_SUCCESS : rc);
     }
 
     /* if the rank is wildcard, then they are asking for the job-level
@@ -414,6 +422,8 @@ static pmix_status_t _satisfy_request(pmix_nspace_t *nptr, pmix_rank_t rank,
         local = true;
         hts[0] = &nptr->server->remote;
         hts[1] = &nptr->server->mylocal;
+    } else if (PMIX_RANK_WILDCARD == rank) {
+        hts[0] = NULL;
     } else {
         local = false;
         hts[0] = &nptr->server->remote;
@@ -440,8 +450,8 @@ static pmix_status_t _satisfy_request(pmix_nspace_t *nptr, pmix_rank_t rank,
 
     /* if they are asking about a rank from an nspace different
      * from their own, then include a copy of the job-level info */
-    if (NULL != cd &&
-        0 != strncmp(nptr->nspace, cd->peer->info->nptr->nspace, PMIX_MAX_NSLEN)) {
+    if (rank == PMIX_RANK_WILDCARD || (NULL != cd &&
+        0 != strncmp(nptr->nspace, cd->peer->info->nptr->nspace, PMIX_MAX_NSLEN))) {
         cur_rank = PMIX_RANK_WILDCARD;
         if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(&pbkt, &cur_rank, 1, PMIX_PROC_RANK))) {
             PMIX_ERROR_LOG(rc);
@@ -457,6 +467,9 @@ static pmix_status_t _satisfy_request(pmix_nspace_t *nptr, pmix_rank_t rank,
             PMIX_DESTRUCT(&pbkt);
             cbfunc(rc, NULL, 0, cbdata, NULL, NULL);
             return rc;
+        }    
+	if (rank == PMIX_RANK_WILDCARD) {
+            found++;
         }
     }
 
@@ -587,10 +600,14 @@ static void _process_dmdx_reply(int fd, short args, void *cbdata)
     }
 
     if (NULL == nptr) {
-        /* should be impossible */
-        PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
-        caddy->status = PMIX_ERR_NOT_FOUND;
-        goto cleanup;
+/*
+ * We may not have this namespace because someone asked about this namespace
+ * but there are not processses from it running on this host
+ */
+        nptr = PMIX_NEW(pmix_nspace_t);
+        (void)strncpy(nptr->nspace, caddy->lcd->proc.nspace, PMIX_MAX_NSLEN);
+        nptr->server = PMIX_NEW(pmix_server_nspace_t);
+        pmix_list_append(&pmix_globals.nspaces, &nptr->super);
     }
 
     /* if the request was successfully satisfied, then store the data
@@ -601,28 +618,33 @@ static void _process_dmdx_reply(int fd, short args, void *cbdata)
      * will let the pmix_pending_resolve function go ahead and retrieve
      * it from the hash table */
     if (PMIX_SUCCESS == caddy->status) {
-        kp = PMIX_NEW(pmix_kval_t);
-        kp->key = strdup("modex");
-        PMIX_VALUE_CREATE(kp->value, 1);
-        kp->value->type = PMIX_BYTE_OBJECT;
-        /* we don't know if the host is going to save this data
-         * or not, so we have to copy it - the client is expecting
-         * this to arrive as a byte object containing a buffer, so
-         * package it accordingly */
-        kp->value->data.bo.bytes = malloc(caddy->ndata);
-        memcpy(kp->value->data.bo.bytes, caddy->data, caddy->ndata);
-        kp->value->data.bo.size = caddy->ndata;
-        /* store it in the appropriate hash */
-        if (PMIX_SUCCESS != (rc = pmix_hash_store(&nptr->server->remote, caddy->lcd->proc.rank, kp))) {
-            PMIX_ERROR_LOG(rc);
+        if (caddy->lcd->proc.rank == PMIX_RANK_WILDCARD) {
+            void * where = malloc(caddy->ndata);
+            memcpy(where, caddy->data, caddy->ndata); 
+            PMIX_LOAD_BUFFER(&nptr->server->job_info, where, caddy->ndata);
+        } else {
+            kp = PMIX_NEW(pmix_kval_t);
+            kp->key = strdup("modex");
+            PMIX_VALUE_CREATE(kp->value, 1);
+            kp->value->type = PMIX_BYTE_OBJECT;
+            /* we don't know if the host is going to save this data
+             * or not, so we have to copy it - the client is expecting
+             * this to arrive as a byte object containing a buffer, so
+             * package it accordingly */
+            kp->value->data.bo.bytes = malloc(caddy->ndata);
+            memcpy(kp->value->data.bo.bytes, caddy->data, caddy->ndata);
+            kp->value->data.bo.size = caddy->ndata;
+            /* store it in the appropriate hash */
+            if (PMIX_SUCCESS != (rc = pmix_hash_store(&nptr->server->remote, caddy->lcd->proc.rank, kp))) {
+                PMIX_ERROR_LOG(rc);
+            }
+            PMIX_RELEASE(kp);  // maintain acctg
         }
-        PMIX_RELEASE(kp);  // maintain acctg
     }
 
     /* always execute the callback to avoid having the client hang */
     pmix_pending_resolve(nptr, caddy->lcd->proc.rank, caddy->status, caddy->lcd);
 
-cleanup:
     /* now call the release function so the host server
      * knows it can release the data */
     if (NULL != caddy->relcbfunc) {


### PR DESCRIPTION
This is a re-organization and rebase of the previous pull request for get changes:

Support a client (likely a tool) to call PMIx_Get on a namespace other than
its own and in particular:

1) call PMIx_Get on a namespace that is not located locally
2) call PMIx_Get on either a specific rank or PMIX_RANK_WILDCARD
   In the later case, we expect job_info data to be collected

To fully support this, the RM code for dmodex get has to be able
to handle the case where we request a rank PMIX_RANK_WILDCARD and
has to know to figure out which host to send that request to to
get the job_info data.