### PR TITLE
dstore: fixed pmix build fails with dstore

### DIFF
--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1038,6 +1038,9 @@ PMIX_EXPORT pmix_status_t PMIx_server_setup_fork(const pmix_proc_t *proc, char *
 {
     char rankstr[128];
     pmix_listener_t *lt;
+#if defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1)
+    pmix_status_t rc;
+#endif
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix:server setup_fork for nspace %s rank %d",


### PR DESCRIPTION
Fixed the pmix build fail with `--dstore-enable` which introduced after the commit 333efe5.

@rhc54 please review