### PR TITLE
dstore: keeping job info in the dstor

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -72,6 +72,7 @@
 #endif /* PMIX_ENABLE_DSTORE */
 
 #include "pmix_client_ops.h"
+#include "src/include/pmix_jobdata.h"
 
 #define PMIX_MAX_RETRIES 10
 
@@ -191,8 +192,11 @@ static void job_data(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
     }
     assert(NULL != nspace);
     free(nspace);
+
     /* decode it */
-    pmix_client_process_nspace_blob(pmix_globals.myid.nspace, buf);
+#if !(defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1))
+    pmix_job_data_htable_store(pmix_globals.myid.nspace, buf);
+#endif
     cb->status = PMIX_SUCCESS;
     cb->active = false;
 }
@@ -1010,160 +1014,8 @@ static pmix_status_t send_connect_ack(int sd)
     return PMIX_SUCCESS;
 }
 
-void pmix_client_process_nspace_blob(const char *nspace, pmix_buffer_t *bptr)
+static pmix_status_t usock_connect(struct sockaddr *addr, int *fd)
 {
-    pmix_status_t rc;
-    int32_t cnt;
-    int rank;
-    pmix_kval_t *kptr, *kp2, kv;
-    pmix_buffer_t buf2;
-    pmix_byte_object_t *bo;
-    size_t nnodes, i, j;
-    pmix_nspace_t *nsptr, *nsptr2;
-    pmix_nrec_t *nrec, *nr2;
-    char **procs;
-
-    pmix_output_verbose(2, pmix_globals.debug_output,
-                        "pmix: PROCESSING BLOB FOR NSPACE %s", nspace);
-
-    /* cycle across our known nspaces */
-    nsptr = NULL;
-    PMIX_LIST_FOREACH(nsptr2, &pmix_globals.nspaces, pmix_nspace_t) {
-        if (0 == strcmp(nsptr2->nspace, nspace)) {
-            nsptr = nsptr2;
-            break;
-        }
-    }
-    if (NULL == nsptr) {
-        /* we don't know this nspace - add it */
-        nsptr = PMIX_NEW(pmix_nspace_t);
-        (void)strncpy(nsptr->nspace, nspace, PMIX_MAX_NSLEN);
-        pmix_list_append(&pmix_globals.nspaces, &nsptr->super);
-    }
-
-    /* unpack any info structs provided */
-    cnt = 1;
-    kptr = PMIX_NEW(pmix_kval_t);
-    while (PMIX_SUCCESS == (rc = pmix_bfrop.unpack(bptr, kptr, &cnt, PMIX_KVAL))) {
-        if (0 == strcmp(kptr->key, PMIX_PROC_BLOB)) {
-            /* transfer the byte object for unpacking */
-            bo = &(kptr->value->data.bo);
-            PMIX_CONSTRUCT(&buf2, pmix_buffer_t);
-            PMIX_LOAD_BUFFER(&buf2, bo->bytes, bo->size);
-            /* start by unpacking the rank */
-            cnt = 1;
-            if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(&buf2, &rank, &cnt, PMIX_PROC_RANK))) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_DESTRUCT(&buf2);
-                return;
-            }
-            kp2 = PMIX_NEW(pmix_kval_t);
-            kp2->key = strdup(PMIX_RANK);
-            PMIX_VALUE_CREATE(kp2->value, 1);
-            kp2->value->type = PMIX_PROC_RANK;
-            kp2->value->data.rank = rank;
-            if (PMIX_SUCCESS != (rc = pmix_hash_store(&nsptr->internal, rank, kp2))) {
-                PMIX_ERROR_LOG(rc);
-            }
-            PMIX_RELEASE(kp2); // maintain accounting
-            cnt = 1;
-            kp2 = PMIX_NEW(pmix_kval_t);
-            while (PMIX_SUCCESS == (rc = pmix_bfrop.unpack(&buf2, kp2, &cnt, PMIX_KVAL))) {
-                /* this is data provided by a job-level exchange, so store it
-                 * in the job-level data hash_table */
-                if (PMIX_SUCCESS != (rc = pmix_hash_store(&nsptr->internal, rank, kp2))) {
-                    PMIX_ERROR_LOG(rc);
-                }
-                PMIX_RELEASE(kp2); // maintain accounting
-                kp2 = PMIX_NEW(pmix_kval_t);
-            }
-            /* cleanup */
-            PMIX_DESTRUCT(&buf2);  // releases the original kptr data
-            PMIX_RELEASE(kp2);
-        } else if (0 == strcmp(kptr->key, PMIX_MAP_BLOB)) {
-            /* transfer the byte object for unpacking */
-            bo = &(kptr->value->data.bo);
-            PMIX_CONSTRUCT(&buf2, pmix_buffer_t);
-            PMIX_LOAD_BUFFER(&buf2, bo->bytes, bo->size);
-            /* start by unpacking the number of nodes */
-            cnt = 1;
-            if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(&buf2, &nnodes, &cnt, PMIX_SIZE))) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_DESTRUCT(&buf2);
-                return;
-            }
-            /* unpack the list of procs on each node */
-            for (i=0; i < nnodes; i++) {
-                cnt = 1;
-                PMIX_CONSTRUCT(&kv, pmix_kval_t);
-                if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(&buf2, &kv, &cnt, PMIX_KVAL))) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_DESTRUCT(&buf2);
-                    PMIX_DESTRUCT(&kv);
-                    return;
-                }
-                /* the name of the node is in the key, and the value is
-                 * a comma-delimited list of procs on that node. See if we already
-                 * have this node */
-                 nrec = NULL;
-                 PMIX_LIST_FOREACH(nr2, &nsptr->nodes, pmix_nrec_t) {
-                    if (0 == strcmp(nr2->name, kv.key)) {
-                        nrec = nr2;
-                        break;
-                    }
-                }
-                if (NULL == nrec) {
-                    /* Create a node record and store that list */
-                    nrec = PMIX_NEW(pmix_nrec_t);
-                    nrec->name = strdup(kv.key);
-                    pmix_list_append(&nsptr->nodes, &nrec->super);
-                } else {
-                    /* refresh the list */
-                    if (NULL != nrec->procs) {
-                        free(nrec->procs);
-                    }
-                }
-                nrec->procs = strdup(kv.value->data.string);
-                /* split the list of procs so we can store their
-                 * individual location data */
-                procs = pmix_argv_split(nrec->procs, ',');
-                for (j=0; NULL != procs[j]; j++) {
-                    /* store the hostname for each proc - again, this is
-                     * data obtained via a job-level exchange, so store it
-                     * in the job-level data hash_table */
-                     kp2 = PMIX_NEW(pmix_kval_t);
-                     kp2->key = strdup(PMIX_HOSTNAME);
-                     kp2->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
-                     kp2->value->type = PMIX_STRING;
-                     kp2->value->data.string = strdup(nrec->name);
-                     rank = strtol(procs[j], NULL, 10);
-                     if (PMIX_SUCCESS != (rc = pmix_hash_store(&nsptr->internal, rank, kp2))) {
-                        PMIX_ERROR_LOG(rc);
-                    }
-                    PMIX_RELEASE(kp2); // maintain accounting
-                }
-                pmix_argv_free(procs);
-                PMIX_DESTRUCT(&kv);
-            }
-            /* cleanup */
-            PMIX_DESTRUCT(&buf2);  // releases the original kptr data
-        } else {
-            /* this is job-level data, so just add it to that hash_table
-             * with the wildcard rank */
-            if (PMIX_SUCCESS != (rc = pmix_hash_store(&nsptr->internal, PMIX_RANK_WILDCARD, kptr))) {
-                PMIX_ERROR_LOG(rc);
-            }
-         }
-         PMIX_RELEASE(kptr);
-         kptr = PMIX_NEW(pmix_kval_t);
-         cnt = 1;
-     }
-    /* need to release the leftover kptr */
-     PMIX_RELEASE(kptr);
- }
-
- static pmix_status_t usock_connect(struct sockaddr *addr, int *fd)
- {
     int sd=-1;
     pmix_status_t rc;
     pmix_socklen_t addrlen = 0;

--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -54,6 +54,7 @@
 #include "src/usock/usock.h"
 
 #include "pmix_client_ops.h"
+#include "src/include/pmix_jobdata.h"
 
 /* callback for wait completion */
 static void wait_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
@@ -313,7 +314,9 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
             continue;
         }
         /* extract and process any proc-related info for this nspace */
-        pmix_client_process_nspace_blob(nspace, bptr);
+#if !(defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1))
+        pmix_job_data_htable_store(nspace, bptr);
+#endif
         PMIX_RELEASE(bptr);
     }
     if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -24,6 +24,7 @@
 #include <pmix_rename.h>
 
 #include "src/include/pmix_globals.h"
+#include "src/include/pmix_jobdata.h"
 
 #ifdef HAVE_STRING_H
 #include <string.h>
@@ -58,6 +59,7 @@
 #endif /* PMIX_ENABLE_DSTORE */
 
 #include "pmix_client_ops.h"
+#include "src/include/pmix_jobdata.h"
 
 static pmix_buffer_t* _pack_get(char *nspace, pmix_rank_t rank,
                                const pmix_info_t info[], size_t ninfo,
@@ -283,8 +285,11 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
         goto done;
     }
 
-#if (PMIX_ENABLE_DSTORE == 1)
-    rc = pmix_dstore_fetch(nptr->nspace, cb->rank, cb->key, &val);
+#if (defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1))
+    if (PMIX_SUCCESS != (rc = pmix_dstore_fetch(nptr->nspace, cb->rank, cb->key, &val))){
+        PMIX_ERROR_LOG(rc);
+        goto done;
+    }
 #else
     /* we received the entire blob for this process, so
      * unpack and store it in the modex - this could consist
@@ -308,7 +313,7 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
                     return;
                 }
                 free(nspace);
-                pmix_client_process_nspace_blob(cb->nspace, bptr);
+                pmix_job_data_htable_store(cb->nspace, bptr);
 
                 /* Check if the key is in this blob */
 
@@ -559,7 +564,11 @@ static void _getnbfn(int fd, short flags, void *cbdata)
      * that was provided at startup */
     if (0 == strncmp(cb->key, "pmix", 4)) {
         /* should be in the internal hash table. */
+#if defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1)
+        if (PMIX_SUCCESS == (rc = pmix_dstore_fetch(cb->nspace, cb->rank, cb->key, &val))) {
+#else
         if (PMIX_SUCCESS == (rc = pmix_hash_fetch(&nptr->internal, cb->rank, cb->key, &val))) {
+#endif
             /* found it - we are in an event, so we can
              * just execute the callback */
             cb->value_cbfunc(rc, val, cb->cbdata);

--- a/src/client/pmix_client_ops.h
+++ b/src/client/pmix_client_ops.h
@@ -26,9 +26,6 @@ typedef struct {
 
 extern pmix_client_globals_t pmix_client_globals;
 
-void pmix_client_process_nspace_blob(const char *nspace, pmix_buffer_t *bptr);
-
-
 END_C_DECLS
 
 #endif /* PMIX_CLIENT_OPS_H */

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -54,6 +54,7 @@
 #include "src/usock/usock.h"
 
 #include "pmix_client_ops.h"
+#include "src/include/pmix_jobdata.h"
 
 static void wait_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
                         pmix_buffer_t *buf, void *cbdata);
@@ -179,7 +180,7 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
 {
     pmix_cb_t *cb = (pmix_cb_t*)cbdata;
     char nspace[PMIX_MAX_NSLEN+1];
-    char *n2;
+    char *n2 = NULL;
     pmix_status_t rc, ret;
     int32_t cnt;
 
@@ -203,10 +204,15 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_usock_hdr_t *hdr,
             PMIX_ERROR_LOG(rc);
             ret = rc;
         }
+        pmix_output_verbose(1, pmix_globals.debug_output,
+                        "pmix:client recv '%s'", n2);
+
         if (NULL != n2) {
             (void)strncpy(nspace, n2, PMIX_MAX_NSLEN);
-            /* extract and process any proc-related info for this nspace */
-            pmix_client_process_nspace_blob(nspace, buf);
+#if !(defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1))
+            /* extract and process any proc-related info for this nspace */            
+            pmix_job_data_htable_store(nspace, buf);
+#endif
             free(n2);
         }
     }

--- a/src/common/Makefile.include
+++ b/src/common/Makefile.include
@@ -12,4 +12,5 @@
 sources += \
         common/pmix_query.c \
         common/pmix_strings.c \
-        common/pmix_log.c
+        common/pmix_log.c \
+        common/pmix_jobdata.c

--- a/src/common/pmix_jobdata.c
+++ b/src/common/pmix_jobdata.c
@@ -1,0 +1,334 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2016      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include <src/include/pmix_config.h>
+#include <pmix_server.h>
+#include <pmix_common.h>
+#include "src/include/pmix_globals.h"
+#include "src/class/pmix_value_array.h"
+#include "src/util/error.h"
+#include "src/buffer_ops/internal.h"
+#include "src/util/argv.h"
+#include "src/util/hash.h"
+#include "src/include/pmix_jobdata.h"
+
+#if defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1)
+#include "src/dstore/pmix_dstore.h"
+#endif
+
+static inline int _add_key_for_rank(pmix_rank_t rank, pmix_kval_t *kv, void *cbdata);
+static inline pmix_status_t _job_data_store(const char *nspace, void *cbdata);
+
+static inline int _add_key_for_rank(pmix_rank_t rank, pmix_kval_t *kv, void *cbdata)
+{
+    pmix_job_data_caddy_t *cb = (pmix_job_data_caddy_t*)(cbdata);
+    pmix_status_t rc = PMIX_SUCCESS;
+#if defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1)
+    uint32_t i, size;
+    pmix_buffer_t *tmp = NULL;
+    pmix_rank_t cur_rank;
+
+    if (NULL != cb->dstore_fn) {
+        /* rank WILDCARD contained in the 0 item */
+        cur_rank = PMIX_RANK_WILDCARD == rank ? 0 : rank + 1;
+        size = (uint32_t)pmix_value_array_get_size(cb->bufs);
+
+        if ((cur_rank + 1) <= size) {
+            tmp = &(PMIX_VALUE_ARRAY_GET_ITEM(cb->bufs, pmix_buffer_t, cur_rank));
+            pmix_bfrop.pack(tmp, kv, 1, PMIX_KVAL);
+            return rc;
+        }
+        if (PMIX_SUCCESS != (rc = pmix_value_array_set_size(cb->bufs, cur_rank + 1))) {
+            PMIX_ERROR_LOG(rc);
+            return rc;
+        }
+        for (i = size; i < (cur_rank + 1); i++) {
+            tmp = &(PMIX_VALUE_ARRAY_GET_ITEM(cb->bufs, pmix_buffer_t, i));
+            PMIX_CONSTRUCT(tmp, pmix_buffer_t);
+        }
+        pmix_bfrop.pack(tmp, kv, 1, PMIX_KVAL);
+    }
+#endif
+    if (cb->hstore_fn) {
+        if (PMIX_SUCCESS != (rc = cb->hstore_fn(&cb->nsptr->internal, rank, kv))) {
+            PMIX_ERROR_LOG(rc);
+        }
+    }
+    return rc;
+}
+
+#if defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1)
+static inline int _rank_key_dstore_store(void *cbdata)
+{
+    int rc = PMIX_SUCCESS;
+    uint32_t i, size;
+    pmix_buffer_t *tmp;
+    pmix_job_data_caddy_t *cb = (pmix_job_data_caddy_t*)cbdata;
+    pmix_rank_t rank;
+    pmix_kval_t *kv = NULL;
+
+    if (NULL == cb->bufs) {
+        rc = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(rc);
+        goto exit;
+    }
+    kv = PMIX_NEW(pmix_kval_t);
+    kv->key = strdup("jobinfo");
+    PMIX_VALUE_CREATE(kv->value, 1);
+    kv->value->type = PMIX_BYTE_OBJECT;
+
+    size = pmix_value_array_get_size(cb->bufs);
+    for (i = 0; i < size; i++) {
+        tmp = &(PMIX_VALUE_ARRAY_GET_ITEM(cb->bufs, pmix_buffer_t, i));
+        rank = 0 == i ? PMIX_RANK_WILDCARD : i - 1;
+        PMIX_UNLOAD_BUFFER(tmp, kv->value->data.bo.bytes, kv->value->data.bo.size);
+        if (PMIX_SUCCESS != (rc = cb->dstore_fn(cb->nsptr->nspace, rank, kv))) {
+            PMIX_ERROR_LOG(rc);
+            goto exit;
+        }
+    }
+
+exit:
+    if (NULL != kv) {
+        PMIX_RELEASE(kv);
+    }
+    return rc;
+}
+#endif
+
+#if defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1)
+pmix_status_t pmix_job_data_dstore_store(const char *nspace, pmix_buffer_t *bptr)
+{
+    pmix_job_data_caddy_t *cd = PMIX_NEW(pmix_job_data_caddy_t);
+
+    cd->job_data = bptr;
+    cd->dstore_fn = pmix_dstore_store;
+
+    return _job_data_store(nspace, cd);
+}
+#endif
+
+pmix_status_t pmix_job_data_htable_store(const char *nspace, pmix_buffer_t *bptr)
+{
+    pmix_job_data_caddy_t *cb = PMIX_NEW(pmix_job_data_caddy_t);
+
+    cb->job_data = bptr;
+    cb->hstore_fn = pmix_hash_store;
+
+    return _job_data_store(nspace, cb);
+}
+
+static inline pmix_status_t _job_data_store(const char *nspace, void *cbdata)
+{
+    pmix_buffer_t *job_data = ((pmix_job_data_caddy_t*)(cbdata))->job_data;
+    pmix_job_data_caddy_t *cb = (pmix_job_data_caddy_t*)(cbdata);
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_nspace_t *nsptr = NULL, *nsptr2 = NULL;
+    pmix_kval_t *kptr, *kp2, kv;
+    int32_t cnt;
+    size_t nnodes;
+    uint32_t i, j;
+    pmix_nrec_t *nrec, *nr2;
+    char **procs;
+    pmix_byte_object_t *bo;
+    pmix_buffer_t buf2;
+    int rank;
+    char *proc_type_str = PMIX_PROC_SERVER == pmix_globals.proc_type ?
+                            "server" : "client";
+
+    pmix_output_verbose(10, pmix_globals.debug_output,
+                    "pmix:%s pmix_jobdata_store %s", proc_type_str, nspace);
+
+    /* check buf data */
+    if ((NULL == job_data) && (0 != job_data->bytes_used)) {
+        rc = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+
+    PMIX_LIST_FOREACH(nsptr2, &pmix_globals.nspaces, pmix_nspace_t) {
+        if (0 == strcmp(nsptr2->nspace, nspace)) {
+            nsptr = nsptr2;
+            break;
+        }
+    }
+    if (NULL == nsptr) {
+        /* we don't know this nspace - add it */
+        nsptr = PMIX_NEW(pmix_nspace_t);
+        (void)strncpy(nsptr->nspace, nspace, PMIX_MAX_NSLEN);
+        pmix_list_append(&pmix_globals.nspaces, &nsptr->super);
+    }
+    cb->nsptr = nsptr;
+
+#if defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1)
+    if (NULL == (cb->bufs = PMIX_NEW(pmix_value_array_t))) {
+        rc = PMIX_ERR_OUT_OF_RESOURCE;
+        PMIX_ERROR_LOG(rc);
+        goto exit;
+    }
+    if (PMIX_SUCCESS != (rc = pmix_value_array_init(cb->bufs, sizeof(pmix_buffer_t)))) {
+        PMIX_ERROR_LOG(rc);
+        goto exit;
+    }
+#endif
+    cnt = 1;
+    kptr = PMIX_NEW(pmix_kval_t);
+    while (PMIX_SUCCESS == (rc = pmix_bfrop.unpack(job_data, kptr, &cnt, PMIX_KVAL)))
+    {
+        if (0 == strcmp(kptr->key, PMIX_PROC_BLOB)) {
+            bo = &(kptr->value->data.bo);
+            PMIX_CONSTRUCT(&buf2, pmix_buffer_t);
+            PMIX_LOAD_BUFFER(&buf2, bo->bytes, bo->size);
+            /* start by unpacking the rank */
+            cnt = 1;
+            if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(&buf2, &rank, &cnt, PMIX_PROC_RANK))) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_DESTRUCT(&buf2);
+                goto exit;
+            }
+            kp2 = PMIX_NEW(pmix_kval_t);
+            kp2->key = strdup(PMIX_RANK);
+            PMIX_VALUE_CREATE(kp2->value, 1);
+            kp2->value->type = PMIX_PROC_RANK;
+            kp2->value->data.rank = rank;
+            if (PMIX_SUCCESS != (rc = _add_key_for_rank(rank, kp2, cb))) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(kp2);
+                PMIX_DESTRUCT(&buf2);
+                goto exit;
+            }
+            PMIX_RELEASE(kp2); // maintain accounting
+            cnt = 1;
+            kp2 = PMIX_NEW(pmix_kval_t);
+            while (PMIX_SUCCESS == (rc = pmix_bfrop.unpack(&buf2, kp2, &cnt, PMIX_KVAL))) {
+                /* this is data provided by a job-level exchange, so store it
+                 * in the job-level data hash_table */
+                if (PMIX_SUCCESS != (rc = _add_key_for_rank(rank, kp2, cb))) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_RELEASE(kp2);
+                    PMIX_DESTRUCT(&buf2);
+                    goto exit;
+                }
+                PMIX_RELEASE(kp2); // maintain accounting
+                kp2 = PMIX_NEW(pmix_kval_t);
+            }
+            /* cleanup */
+            PMIX_DESTRUCT(&buf2);  // releases the original kptr data
+            PMIX_RELEASE(kp2);
+        } else if (0 == strcmp(kptr->key, PMIX_MAP_BLOB)) {
+            /* transfer the byte object for unpacking */
+            bo = &(kptr->value->data.bo);
+            PMIX_CONSTRUCT(&buf2, pmix_buffer_t);
+            PMIX_LOAD_BUFFER(&buf2, bo->bytes, bo->size);
+            /* start by unpacking the number of nodes */
+            cnt = 1;
+            if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(&buf2, &nnodes, &cnt, PMIX_SIZE))) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_DESTRUCT(&buf2);
+                goto exit;
+            }
+            /* unpack the list of procs on each node */
+            for (i=0; i < nnodes; i++) {
+                cnt = 1;
+                PMIX_CONSTRUCT(&kv, pmix_kval_t);
+                if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(&buf2, &kv, &cnt, PMIX_KVAL))) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_DESTRUCT(&buf2);
+                    PMIX_DESTRUCT(&kv);
+                    goto exit;
+                }
+                /* the name of the node is in the key, and the value is
+                 * a comma-delimited list of procs on that node. See if we already
+                 * have this node */
+                nrec = NULL;
+                PMIX_LIST_FOREACH(nr2, &nsptr->nodes, pmix_nrec_t) {
+                    if (0 == strcmp(nr2->name, kv.key)) {
+                        nrec = nr2;
+                        break;
+                    }
+                }
+                if (NULL == nrec) {
+                    /* Create a node record and store that list */
+                    nrec = PMIX_NEW(pmix_nrec_t);
+                    nrec->name = strdup(kv.key);
+                    pmix_list_append(&nsptr->nodes, &nrec->super);
+                } else {
+                    /* refresh the list */
+                    if (NULL != nrec->procs) {
+                        free(nrec->procs);
+                    }
+                }
+                nrec->procs = strdup(kv.value->data.string);
+                /* split the list of procs so we can store their
+                 * individual location data */
+                procs = pmix_argv_split(nrec->procs, ',');
+                for (j=0; NULL != procs[j]; j++) {
+                    /* store the hostname for each proc - again, this is
+                     * data obtained via a job-level exchange, so store it
+                     * in the job-level data hash_table */
+                    kp2 = PMIX_NEW(pmix_kval_t);
+                    kp2->key = strdup(PMIX_HOSTNAME);
+                    kp2->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+                    kp2->value->type = PMIX_STRING;
+                    kp2->value->data.string = strdup(nrec->name);
+                    rank = strtol(procs[j], NULL, 10);
+                    if (PMIX_SUCCESS != (rc = _add_key_for_rank(rank, kp2, cb))) {
+                        PMIX_ERROR_LOG(rc);
+                        PMIX_RELEASE(kp2);
+                        PMIX_DESTRUCT(&kv);
+                        PMIX_DESTRUCT(&buf2);
+                        pmix_argv_free(procs);
+                        goto exit;
+                    }
+                    PMIX_RELEASE(kp2);
+                }
+                pmix_argv_free(procs);
+                PMIX_DESTRUCT(&kv);
+            }
+            /* cleanup */
+            PMIX_DESTRUCT(&buf2);
+        } else {
+            if (PMIX_SUCCESS != (rc = _add_key_for_rank(PMIX_RANK_WILDCARD, kptr, cb))) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(kptr);
+                goto exit;
+            }
+        }
+        PMIX_RELEASE(kptr);
+        kptr = PMIX_NEW(pmix_kval_t);
+        cnt = 1;
+    }
+    /* need to release the leftover kptr */
+    PMIX_RELEASE(kptr);
+
+#if defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1)
+    if (NULL != cb->dstore_fn) {
+        uint32_t size = (uint32_t)pmix_value_array_get_size(cb->bufs);
+        for (i = 0; i < size; i++) {
+            if (PMIX_SUCCESS != (rc = _rank_key_dstore_store(cbdata))) {
+                PMIX_ERROR_LOG(rc);
+                goto exit;
+            }
+        }
+    }
+#endif
+exit:
+#if defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1)
+    if (NULL != cb->bufs) {
+        PMIX_RELEASE(cb->bufs);
+    }
+#endif
+    PMIX_RELEASE(cb);
+
+    /* reset buf unpack ptr */
+    job_data->unpack_ptr = job_data->base_ptr;
+
+    return rc;
+}

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -206,3 +206,18 @@ static void qcon(pmix_query_caddy_t *p)
 PMIX_CLASS_INSTANCE(pmix_query_caddy_t,
                     pmix_object_t,
                     qcon, NULL);
+
+static void jdcon(pmix_job_data_caddy_t *p)
+{
+    p->nsptr = NULL;
+    p->job_data = NULL;
+    p->dstore_fn = NULL;
+    p->hstore_fn = NULL;
+#if defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1)
+    p->bufs = NULL;
+#endif
+}
+
+PMIX_CLASS_INSTANCE(pmix_job_data_caddy_t,
+                    pmix_object_t,
+                    jdcon, NULL);

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -270,6 +270,23 @@ typedef struct {
 } pmix_server_trkr_t;
 PMIX_CLASS_DECLARATION(pmix_server_trkr_t);
 
+typedef int (*pmix_store_dstor_cbfunc_t)(const char *nsname,
+                                         pmix_rank_t rank, pmix_kval_t *kv);
+typedef int (*pmix_store_hash_cbfunc_t)(pmix_hash_table_t *table,
+                                         pmix_rank_t rank, pmix_kval_t *kv);
+
+typedef struct {
+    pmix_object_t super;
+    pmix_nspace_t *nsptr;
+    pmix_buffer_t *job_data;
+    pmix_store_dstor_cbfunc_t dstore_fn;
+    pmix_store_hash_cbfunc_t hstore_fn;
+#if defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1)
+    /* array of buffers per rank */
+    pmix_value_array_t *bufs;
+#endif
+} pmix_job_data_caddy_t;
+PMIX_CLASS_DECLARATION(pmix_job_data_caddy_t);
 
 /****    THREAD-RELATED    ****/
  /* define a caddy for thread-shifting operations */

--- a/src/include/pmix_jobdata.h
+++ b/src/include/pmix_jobdata.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_JOBDATA_H
+#define PMIX_JOBDATA_H
+
+#include <src/include/pmix_config.h>
+
+#include "src/buffer_ops/buffer_ops.h"
+#include "src/class/pmix_hash_table.h"
+
+#if defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1)
+pmix_status_t pmix_job_data_dstore_store(const char *nspace, pmix_buffer_t *bptr);
+#endif
+pmix_status_t pmix_job_data_htable_store(const char *nspace, pmix_buffer_t *bptr);
+
+#endif // PMIX_JOBDATA_H

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -65,6 +65,7 @@
 #if defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1)
 #include "src/dstore/pmix_dstore.h"
 #endif /* PMIX_ENABLE_DSTORE */
+#include "src/include/pmix_jobdata.h"
 
 #include "pmix_server_ops.h"
 
@@ -518,9 +519,14 @@ static void _register_nspace(int sd, short args, void *cbdata)
     pmix_info_t *iptr;
     pmix_value_t val;
     char *msg;
+#if defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1)
+    pmix_buffer_t *jobdata = PMIX_NEW(pmix_buffer_t);
+    char *nspace = NULL;
+    int32_t cnt;
+#endif
 
     pmix_output_verbose(2, pmix_globals.debug_output,
-                        "pmix:server _register_nspace");
+                        "pmix:server _register_nspace %s", cd->proc.nspace);
 
     /* see if we already have this nspace */
     nptr = NULL;
@@ -647,6 +653,7 @@ static void _register_nspace(int sd, short args, void *cbdata)
             /* just a value relating to the entire job */
             kv.key = cd->info[i].key;
             kv.value = &cd->info[i].value;
+
             if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(&nptr->server->job_info, &kv, 1, PMIX_KVAL))) {
                 PMIX_ERROR_LOG(rc);
                 pmix_list_remove_item(&pmix_globals.nspaces, &nptr->super);
@@ -662,6 +669,20 @@ static void _register_nspace(int sd, short args, void *cbdata)
         PMIX_ERROR_LOG(rc);
         goto release;
     }
+    pmix_bfrop.copy_payload(jobdata, &nptr->server->job_info);
+    pmix_bfrop.copy_payload(jobdata, &pmix_server_globals.gdata);
+
+    /* unpack the nspace - we don't really need it, but have to
+    * unpack it to maintain sequence */
+    cnt = 1;
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(jobdata, &nspace, &cnt, PMIX_STRING))) {
+        PMIX_ERROR_LOG(rc);
+        goto release;
+    }
+    if (PMIX_SUCCESS != (rc = pmix_job_data_dstore_store(cd->proc.nspace, jobdata))) {
+        PMIX_ERROR_LOG(rc);
+        goto release;
+    }
 #endif
 
  release:
@@ -674,6 +695,14 @@ static void _register_nspace(int sd, short args, void *cbdata)
     if (NULL != cd->opcbfunc) {
         cd->opcbfunc(rc, cd->cbdata);
     }
+#if defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1)
+    if (NULL != nspace) {
+        free(nspace);
+    }
+    if (NULL != jobdata) {
+        PMIX_RELEASE(jobdata);
+    }
+#endif
     PMIX_RELEASE(cd);
 }
 
@@ -2196,8 +2225,17 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag,
 
     if (PMIX_REQ_CMD == cmd) {
         reply = PMIX_NEW(pmix_buffer_t);
+
+#if defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1)
+        char *msg = peer->info->nptr->nspace;
+        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(reply, &msg, 1, PMIX_STRING))) {
+            PMIX_ERROR_LOG(rc);
+            return rc;
+        }
+#else
         pmix_bfrop.copy_payload(reply, &(peer->info->nptr->server->job_info));
         pmix_bfrop.copy_payload(reply, &(pmix_server_globals.gdata));
+#endif
         PMIX_SERVER_QUEUE_REPLY(peer, tag, reply);
         return PMIX_SUCCESS;
     }


### PR DESCRIPTION
Reduction of memory usage on pmix-client's side by to not duplicate
the job data for each client's:
- Job info will not be sent to clients when connecting to the server.
- The server will provide the job information into `dstore`.
- The client will use the `dstore` for access to job info.

Fixes #144 