### PR TITLE
Add network support APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ examples/dmodex
 examples/dynamic
 examples/fault
 examples/pub
+examples/server
 examples/tool
 
 include/pmix_version.h

--- a/config/pmix_check_psm2.m4
+++ b/config/pmix_check_psm2.m4
@@ -1,0 +1,89 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2006 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2006      QLogic Corp. All rights reserved.
+# Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016      Intel Corporation. All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# PMIX_CHECK_PSM2(prefix, [action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+# check if PSM2 support can be found.  sets prefix_{CPPFLAGS,
+# LDFLAGS, LIBS} as needed and runs action-if-found if there is
+# support, otherwise executes action-if-not-found
+AC_DEFUN([PMIX_CHECK_PSM2],[
+    if test -z "$pmix_check_psm2_happy" ; then
+	AC_ARG_WITH([psm2],
+		    [AC_HELP_STRING([--with-psm2(=DIR)],
+				    [Build PSM2 (Intel PSM2) support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
+	PMIX_CHECK_WITHDIR([psm2], [$with_psm2], [include/psm2.h])
+	AC_ARG_WITH([psm2-libdir],
+		    [AC_HELP_STRING([--with-psm2-libdir=DIR],
+				    [Search for PSM (Intel PSM2) libraries in DIR])])
+	PMIX_CHECK_WITHDIR([psm2-libdir], [$with_psm2_libdir], [libpsm2.*])
+
+	pmix_check_psm2_$1_save_CPPFLAGS="$CPPFLAGS"
+	pmix_check_psm2_$1_save_LDFLAGS="$LDFLAGS"
+	pmix_check_psm2_$1_save_LIBS="$LIBS"
+
+	AS_IF([test "$with_psm2" != "no"],
+              [AS_IF([test ! -z "$with_psm2" && test "$with_psm2" != "yes"],
+                     [pmix_check_psm2_dir="$with_psm2"])
+               AS_IF([test ! -z "$with_psm2_libdir" && test "$with_psm2_libdir" != "yes"],
+                     [pmix_check_psm2_libdir="$with_psm2_libdir"])
+
+               PMIX_CHECK_PACKAGE([pmix_check_psm2],
+				  [psm2.h],
+				  [psm2],
+				  [psm_mq_irecv],
+				  [],
+				  [$pmix_check_psm2_dir],
+				  [$pmix_check_psm2_libdir],
+				  [pmix_check_psm2_happy="yes"],
+				  [pmix_check_psm2_happy="no"])],
+              [pmix_check_psm2_happy="no"])
+
+	CPPFLAGS="$pmix_check_psm2_$1_save_CPPFLAGS"
+	LDFLAGS="$pmix_check_psm2_$1_save_LDFLAGS"
+	LIBS="$pmix_check_psm2_$1_save_LIBS"
+
+	AS_IF([test "$pmix_check_psm2_happy" = "yes" && test "$enable_progress_threads" = "yes"],
+              [AC_MSG_WARN([PSM2 driver does not currently support progress threads.  Disabling MTL.])
+               pmix_check_psm2_happy="no"])
+
+        AS_IF([test "$pmix_check_psm2_happy" = "yes"],
+              [AC_CHECK_HEADERS(
+               glob.h,
+               [],
+               [AC_MSG_WARN([glob.h not found.  Can not build component.])
+               pmix_check_psm2_happy="no"])])
+
+    fi
+
+    AS_IF([test "$pmix_check_psm2_happy" = "yes"],
+          [$1_LDFLAGS="[$]$1_LDFLAGS $pmix_check_psm2_LDFLAGS"
+	   $1_CPPFLAGS="[$]$1_CPPFLAGS $pmix_check_psm2_CPPFLAGS"
+	   $1_LIBS="[$]$1_LIBS $pmix_check_psm2_LIBS"
+	   $2],
+          [AS_IF([test ! -z "$with_psm2" && test "$with_psm2" != "no"],
+                 [AC_MSG_ERROR([PSM2 support requested but not found.  Aborting])])
+           $3])
+])

--- a/config/pmix_check_withdir.m4
+++ b/config/pmix_check_withdir.m4
@@ -1,0 +1,39 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
+dnl                         University Research and Technology
+dnl                         Corporation.  All rights reserved.
+dnl Copyright (c) 2006      Los Alamos National Security, LLC.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2008-2009 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2015      Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2016      Intel, Inc.  All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+# PMIX_CHECK_WITHDIR(with_option_name, dir_value, file_in_dir)
+# ----------------------------------------------------
+AC_DEFUN([PMIX_CHECK_WITHDIR],[
+    AC_MSG_CHECKING([--with-$1 value])
+    AS_IF([test "$2" = "yes" || test "$2" = "no" || test "x$2" = "x"],
+          [AC_MSG_RESULT([simple ok (unspecified)])],
+          [AS_IF([test ! -d "$2"],
+                 [AC_MSG_RESULT([not found])
+                  AC_MSG_WARN([Directory $2 not found])
+                  AC_MSG_ERROR([Cannot continue])],
+                 [AS_IF([test "x`ls $2/$3 2> /dev/null`" = "x"],
+                        [AC_MSG_RESULT([not found])
+                         AC_MSG_WARN([Expected file $2/$3 not found])
+                         AC_MSG_ERROR([Cannot continue])],
+                        [AC_MSG_RESULT([sanity check ok ($2)])]
+                       )
+                 ]
+                )
+          ]
+         )
+])dnl

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -19,13 +19,19 @@
 # $HEADER$
 #
 
-AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/src/api
+AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix
 
 noinst_PROGRAMS = client dmodex dynamic fault pub tool
 if !WANT_HIDDEN
 # these examples use internal symbols
 # use --disable-visibility
 noinst_PROGRAMS += debugger debuggerd
+endif
+
+if !WANT_HIDDEN
+# this example uses internal symbols
+# use --disable-visibility
+noinst_PROGRAMS += server
 endif
 
 client_SOURCES = client.c
@@ -61,6 +67,14 @@ pub_LDADD = $(top_builddir)/src/libpmix.la
 tool_SOURCES = tool.c
 tool_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 tool_LDADD = $(top_builddir)/src/libpmix.la
+
+if !WANT_HIDDEN
+# this example uses internal symbols
+# use --disable-visibility
+server_SOURCES = server.c
+server_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+server_LDADD = $(top_builddir)/src/libpmix.la
+endif
 
 distclean-local:
 	rm -f *.o client debugger debuggerd dmodex dynamic fault pub server

--- a/examples/server.c
+++ b/examples/server.c
@@ -1,0 +1,893 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include <src/include/pmix_config.h>
+#include <pmix_server.h>
+#include <src/include/types.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <errno.h>
+#include <signal.h>
+#include <pwd.h>
+#include <sys/stat.h>
+#include <dirent.h>
+
+#include PMIX_EVENT_HEADER
+
+#include "src/class/pmix_list.h"
+#include "src/util/pmix_environ.h"
+#include "src/util/output.h"
+#include "src/util/printf.h"
+#include "src/util/argv.h"
+#include "src/buffer_ops/buffer_ops.h"
+
+static pmix_status_t connected(const pmix_proc_t *proc, void *server_object,
+                               pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t finalized(const pmix_proc_t *proc, void *server_object,
+                               pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t abort_fn(const pmix_proc_t *proc, void *server_object,
+                              int status, const char msg[],
+                              pmix_proc_t procs[], size_t nprocs,
+                              pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
+                                const pmix_info_t info[], size_t ninfo,
+                                char *data, size_t ndata,
+                                pmix_modex_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t dmodex_fn(const pmix_proc_t *proc,
+                               const pmix_info_t info[], size_t ninfo,
+                               pmix_modex_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t publish_fn(const pmix_proc_t *proc,
+                                const pmix_info_t info[], size_t ninfo,
+                                pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t lookup_fn(const pmix_proc_t *proc, char **keys,
+                               const pmix_info_t info[], size_t ninfo,
+                               pmix_lookup_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t unpublish_fn(const pmix_proc_t *proc, char **keys,
+                                  const pmix_info_t info[], size_t ninfo,
+                                  pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t spawn_fn(const pmix_proc_t *proc,
+                              const pmix_info_t job_info[], size_t ninfo,
+                              const pmix_app_t apps[], size_t napps,
+                              pmix_spawn_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
+                                const pmix_info_t info[], size_t ninfo,
+                                pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
+                                   const pmix_info_t info[], size_t ninfo,
+                                   pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t register_event_fn(pmix_status_t *codes, size_t ncodes,
+                                       const pmix_info_t info[], size_t ninfo,
+                                       pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t deregister_events(pmix_status_t *codes, size_t ncodes,
+                                       pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t notify_event(pmix_status_t code,
+                                  const pmix_proc_t *source,
+                                  pmix_data_range_t range,
+                                  pmix_info_t info[], size_t ninfo,
+                                  pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t query_fn(pmix_proc_t *proct,
+                              pmix_query_t *queries, size_t nqueries,
+                              pmix_info_cbfunc_t cbfunc,
+                              void *cbdata);
+static void tool_connect_fn(pmix_info_t *info, size_t ninfo,
+                            pmix_tool_connection_cbfunc_t cbfunc,
+                            void *cbdata);
+static void log_fn(const pmix_proc_t *client,
+                   const pmix_info_t data[], size_t ndata,
+                   const pmix_info_t directives[], size_t ndirs,
+                   pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+static pmix_server_module_t mymodule = {
+    .client_connected = connected,
+    .client_finalized = finalized,
+    .abort = abort_fn,
+    .fence_nb = fencenb_fn,
+    .direct_modex = dmodex_fn,
+    .publish = publish_fn,
+    .lookup = lookup_fn,
+    .unpublish = unpublish_fn,
+    .spawn = spawn_fn,
+    .connect = connect_fn,
+    .disconnect = disconnect_fn,
+    .register_events = register_event_fn,
+    .deregister_events = deregister_events,
+    .notify_event = notify_event,
+    .query = query_fn,
+    .tool_connected = tool_connect_fn,
+    .log = log_fn
+};
+
+typedef struct {
+    pmix_list_item_t super;
+    pmix_pdata_t pdata;
+} pmix_locdat_t;
+PMIX_CLASS_INSTANCE(pmix_locdat_t,
+                    pmix_list_item_t,
+                    NULL, NULL);
+
+typedef struct {
+    pmix_object_t super;
+    volatile bool active;
+    pmix_proc_t caller;
+    pmix_info_t *info;
+    size_t ninfo;
+    pmix_op_cbfunc_t cbfunc;
+    pmix_spawn_cbfunc_t spcbfunc;
+    void *cbdata;
+} myxfer_t;
+static void xfcon(myxfer_t *p)
+{
+    p->info = NULL;
+    p->ninfo = 0;
+    p->active = true;
+    p->cbfunc = NULL;
+    p->spcbfunc = NULL;
+    p->cbdata = NULL;
+}
+static void xfdes(myxfer_t *p)
+{
+    if (NULL != p->info) {
+        PMIX_INFO_FREE(p->info, p->ninfo);
+    }
+}
+PMIX_CLASS_INSTANCE(myxfer_t,
+                    pmix_object_t,
+                    xfcon, xfdes);
+
+typedef struct {
+    pmix_list_item_t super;
+    pid_t pid;
+} wait_tracker_t;
+PMIX_CLASS_INSTANCE(wait_tracker_t,
+                    pmix_list_item_t,
+                    NULL, NULL);
+
+static volatile int wakeup;
+static pmix_list_t pubdata;
+static pmix_event_t handler;
+static pmix_list_t children;
+
+static void set_namespace(int nprocs, char *ranks, char *nspace,
+                          pmix_op_cbfunc_t cbfunc, myxfer_t *x);
+static void errhandler(size_t evhdlr_registration_id,
+                       pmix_status_t status,
+                       const pmix_proc_t *source,
+                       pmix_info_t info[], size_t ninfo,
+                       pmix_info_t results[], size_t nresults,
+                       pmix_event_notification_cbfunc_fn_t cbfunc,
+                       void *cbdata);
+static void wait_signal_callback(int fd, short event, void *arg);
+static void errhandler_reg_callbk (pmix_status_t status,
+                                   size_t errhandler_ref,
+                                   void *cbdata);
+
+static void opcbfunc(pmix_status_t status, void *cbdata)
+{
+    myxfer_t *x = (myxfer_t*)cbdata;
+
+    /* release the caller, if necessary */
+    if (NULL != x->cbfunc) {
+        x->cbfunc(PMIX_SUCCESS, x->cbdata);
+    }
+    x->active = false;
+}
+
+int main(int argc, char **argv)
+{
+    char **client_env=NULL;
+    char **client_argv=NULL;
+    char *tmp, **atmp, *executable=NULL, *tmpdir, *cleanup;
+    int rc, nprocs=1, n, k;
+    uid_t myuid;
+    gid_t mygid;
+    pid_t pid;
+    myxfer_t *x;
+    pmix_proc_t proc;
+    wait_tracker_t *child;
+    char *tdir;
+    uid_t uid = geteuid();
+    pmix_info_t *info;
+    struct stat buf;
+
+    /* define and pass a personal tmpdir to protect the system */
+    if (NULL == (tdir = getenv("TMPDIR"))) {
+        if (NULL == (tdir = getenv("TEMP"))) {
+            if (NULL == (tdir = getenv("TMP"))) {
+                tdir = "/tmp";
+            }
+        }
+    }
+    if (0 > asprintf(&tmpdir, "%s/pmix.%lu", tdir, (long unsigned)uid)) {
+        fprintf(stderr, "Out of memory\n");
+        exit(1);
+    }
+    /* create the directory */
+    if (0 != stat(tmpdir, &buf)) {
+        /* try to make directory */
+        if (0 != mkdir(tmpdir, S_IRWXU)) {
+            fprintf(stderr, "Cannot make tmpdir %s", tmpdir);
+            exit(1);
+        }
+    }
+    asprintf(&cleanup, "rm -rf %s", tmpdir);
+    PMIX_INFO_CREATE(info, 1);
+    PMIX_INFO_LOAD(&info[0], PMIX_SERVER_TMPDIR, tmpdir, PMIX_STRING);
+
+    /* setup the server library */
+    if (PMIX_SUCCESS != (rc = PMIx_server_init(&mymodule, info, 1))) {
+        fprintf(stderr, "Init failed with error %d\n", rc);
+        return rc;
+    }
+    PMIX_INFO_FREE(info, 1);
+
+    /* register the errhandler */
+    PMIx_Register_event_handler(NULL, 0, NULL, 0,
+                                errhandler, errhandler_reg_callbk, NULL);
+
+    /* setup the pub data, in case it is used */
+    PMIX_CONSTRUCT(&pubdata, pmix_list_t);
+
+    /* setup to see sigchld on the forked tests */
+    PMIX_CONSTRUCT(&children, pmix_list_t);
+    event_assign(&handler, pmix_globals.evbase, SIGCHLD,
+                 EV_SIGNAL|EV_PERSIST,wait_signal_callback, &handler);
+    event_add(&handler, NULL);
+
+    /* see if we were passed the number of procs to run or
+     * the executable to use */
+    for (n=1; n < (argc-1); n++) {
+        if (0 == strcmp("-n", argv[n]) &&
+            NULL != argv[n+1]) {
+            nprocs = strtol(argv[n+1], NULL, 10);
+            ++n;  // step over the argument
+        } else if (0 == strcmp("-e", argv[n]) &&
+                   NULL != argv[n+1]) {
+            executable = strdup(argv[n+1]);
+            for (k=n+2; NULL != argv[k]; k++) {
+                pmix_argv_append_nosize(&client_argv, argv[k]);
+            }
+            n += k;
+        }
+    }
+    if (NULL == executable) {
+        executable = strdup("./simpclient");
+    }
+
+    /* we have a single namespace for all clients */
+    atmp = NULL;
+    for (n=0; n < nprocs; n++) {
+        asprintf(&tmp, "%d", n);
+        pmix_argv_append_nosize(&atmp, tmp);
+        free(tmp);
+    }
+    tmp = pmix_argv_join(atmp, ',');
+    pmix_argv_free(atmp);
+    /* register the nspace */
+    x = PMIX_NEW(myxfer_t);
+    set_namespace(nprocs, tmp, "foobar", opcbfunc, x);
+
+    /* set common argv and env */
+    client_env = pmix_argv_copy(environ);
+    pmix_argv_prepend_nosize(&client_argv, executable);
+
+    wakeup = nprocs;
+    myuid = getuid();
+    mygid = getgid();
+
+    /* if the nspace registration hasn't completed yet,
+     * wait for it here */
+    PMIX_WAIT_FOR_COMPLETION(x->active);
+    free(tmp);
+    PMIX_RELEASE(x);
+
+    /* prep the local node for launch */
+    x = PMIX_NEW(myxfer_t);
+    if (PMIX_SUCCESS != (rc = PMIx_server_setup_local_support("foobar", NULL, 0, opcbfunc, x))) {
+        fprintf(stderr, "Setup local support failed: %d\n", rc);
+        PMIx_server_finalize();
+        system(cleanup);
+        return rc;
+    }
+    PMIX_WAIT_FOR_COMPLETION(x->active);
+    PMIX_RELEASE(x);
+
+    /* fork/exec the test */
+    (void)strncpy(proc.nspace, "foobar", PMIX_MAX_NSLEN);
+    for (n = 0; n < nprocs; n++) {
+        proc.rank = n;
+        if (PMIX_SUCCESS != (rc = PMIx_server_setup_fork(&proc, &client_env))) {//n
+            fprintf(stderr, "Server fork setup failed with error %d\n", rc);
+            PMIx_server_finalize();
+            system(cleanup);
+            return rc;
+        }
+        x = PMIX_NEW(myxfer_t);
+        if (PMIX_SUCCESS != (rc = PMIx_server_register_client(&proc, myuid, mygid,
+                                                              NULL, opcbfunc, x))) {
+            fprintf(stderr, "Server fork setup failed with error %d\n", rc);
+            PMIx_server_finalize();
+            system(cleanup);
+            return rc;
+        }
+        /* don't fork/exec the client until we know it is registered
+         * so we avoid a potential race condition in the server */
+        PMIX_WAIT_FOR_COMPLETION(x->active);
+        PMIX_RELEASE(x);
+        pid = fork();
+        if (pid < 0) {
+            fprintf(stderr, "Fork failed\n");
+            PMIx_server_finalize();
+            system(cleanup);
+            return -1;
+        }
+        child = PMIX_NEW(wait_tracker_t);
+        child->pid = pid;
+        pmix_list_append(&children, &child->super);
+
+        if (pid == 0) {
+            execve(executable, client_argv, client_env);
+            /* Does not return */
+            exit(0);
+        }
+    }
+    free(executable);
+    pmix_argv_free(client_argv);
+    pmix_argv_free(client_env);
+
+    /* hang around until the client(s) finalize */
+    while (0 < wakeup) {
+        struct timespec ts;
+        ts.tv_sec = 0;
+        ts.tv_nsec = 100000;
+        nanosleep(&ts, NULL);
+    }
+
+    /* deregister the errhandler */
+    PMIx_Deregister_event_handler(0, NULL, NULL);
+
+    /* release any pub data */
+    PMIX_LIST_DESTRUCT(&pubdata);
+
+    /* finalize the server library */
+    if (PMIX_SUCCESS != (rc = PMIx_server_finalize())) {
+        fprintf(stderr, "Finalize failed with error %d\n", rc);
+    }
+
+    fprintf(stderr, "Test finished OK!\n");
+    system(cleanup);
+
+    return rc;
+}
+
+static void setup_cbfunc(pmix_status_t status,
+                         pmix_info_t info[], size_t ninfo,
+                         void *provided_cbdata,
+                         pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    myxfer_t *myxfer = (myxfer_t*)provided_cbdata;
+    size_t i;
+
+    if (PMIX_SUCCESS == status && 0 < ninfo) {
+        myxfer->ninfo = ninfo;
+        PMIX_INFO_CREATE(myxfer->info, ninfo);
+        for (i=0; i < ninfo; i++) {
+            PMIX_INFO_XFER(&myxfer->info[i], &info[i]);
+        }
+    }
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+    myxfer->active = false;
+}
+
+static void set_namespace(int nprocs, char *ranks, char *nspace,
+                          pmix_op_cbfunc_t cbfunc, myxfer_t *x)
+{
+    char *regex, *ppn;
+    char hostname[PMIX_MAXHOSTNAMELEN];
+    pmix_status_t rc;
+    myxfer_t myxfer;
+    size_t i;
+
+    gethostname(hostname, sizeof(hostname));
+
+    /* request application setup information - e.g., network
+     * security keys or endpoint info */
+    PMIX_CONSTRUCT(&myxfer, myxfer_t);
+    myxfer.active = true;
+    if (PMIX_SUCCESS != (rc = PMIx_server_setup_application(nspace, NULL, 0, setup_cbfunc, &myxfer))) {
+        PMIX_DESTRUCT(&myxfer);
+        fprintf(stderr, "Failed to setup application: %d\n", rc);
+        exit(1);
+    }
+    PMIX_WAIT_FOR_COMPLETION(myxfer.active);
+    x->ninfo = myxfer.ninfo + 7;
+
+    PMIX_INFO_CREATE(x->info, x->ninfo);
+    if (0 < myxfer.ninfo) {
+        for (i=0; i < myxfer.ninfo; i++) {
+            PMIX_INFO_XFER(&x->info[i], &myxfer.info[i]);
+        }
+    }
+    PMIX_DESTRUCT(&myxfer);
+
+    (void)strncpy(x->info[i].key, PMIX_UNIV_SIZE, PMIX_MAX_KEYLEN);
+    x->info[i].value.type = PMIX_UINT32;
+    x->info[i].value.data.uint32 = nprocs;
+
+    ++i;
+    (void)strncpy(x->info[i].key, PMIX_SPAWNED, PMIX_MAX_KEYLEN);
+    x->info[i].value.type = PMIX_UINT32;
+    x->info[i].value.data.uint32 = 0;
+
+    ++i;
+    (void)strncpy(x->info[i].key, PMIX_LOCAL_SIZE, PMIX_MAX_KEYLEN);
+    x->info[i].value.type = PMIX_UINT32;
+    x->info[i].value.data.uint32 = nprocs;
+
+    ++i;
+    (void)strncpy(x->info[i].key, PMIX_LOCAL_PEERS, PMIX_MAX_KEYLEN);
+    x->info[i].value.type = PMIX_STRING;
+    x->info[i].value.data.string = strdup(ranks);
+
+    ++i;
+    PMIx_generate_regex(hostname, &regex);
+    (void)strncpy(x->info[i].key, PMIX_NODE_MAP, PMIX_MAX_KEYLEN);
+    x->info[i].value.type = PMIX_STRING;
+    x->info[i].value.data.string = regex;
+
+    ++i;
+    PMIx_generate_ppn(ranks, &ppn);
+    (void)strncpy(x->info[i].key, PMIX_PROC_MAP, PMIX_MAX_KEYLEN);
+    x->info[i].value.type = PMIX_STRING;
+    x->info[i].value.data.string = ppn;
+
+    ++i;
+    (void)strncpy(x->info[i].key, PMIX_JOB_SIZE, PMIX_MAX_KEYLEN);
+    x->info[i].value.type = PMIX_UINT32;
+    x->info[i].value.data.uint32 = nprocs;
+
+    PMIx_server_register_nspace(nspace, nprocs, x->info, x->ninfo,
+                                cbfunc, x);
+}
+
+static void errhandler(size_t evhdlr_registration_id,
+                       pmix_status_t status,
+                       const pmix_proc_t *source,
+                       pmix_info_t info[], size_t ninfo,
+                       pmix_info_t results[], size_t nresults,
+                       pmix_event_notification_cbfunc_fn_t cbfunc,
+                       void *cbdata)
+{
+    pmix_output(0, "SERVER: ERRHANDLER CALLED WITH STATUS %d", status);
+}
+
+static void errhandler_reg_callbk (pmix_status_t status,
+                                   size_t errhandler_ref,
+                                   void *cbdata)
+{
+    return;
+}
+
+static pmix_status_t connected(const pmix_proc_t *proc, void *server_object,
+                               pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+    return PMIX_SUCCESS;
+}
+static pmix_status_t finalized(const pmix_proc_t *proc, void *server_object,
+                     pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_output(0, "SERVER: FINALIZED %s:%d",
+                proc->nspace, proc->rank);
+    --wakeup;
+    /* ensure we call the cbfunc so the proc can exit! */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+    return PMIX_SUCCESS;
+}
+
+static void abcbfunc(pmix_status_t status, void *cbdata)
+{
+    myxfer_t *x = (myxfer_t*)cbdata;
+
+    /* be sure to release the caller */
+    if (NULL != x->cbfunc) {
+        x->cbfunc(status, x->cbdata);
+    }
+    PMIX_RELEASE(x);
+}
+
+static pmix_status_t abort_fn(const pmix_proc_t *proc,
+                              void *server_object,
+                              int status, const char msg[],
+                              pmix_proc_t procs[], size_t nprocs,
+                              pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_status_t rc;
+    myxfer_t *x;
+
+    if (NULL != procs) {
+        pmix_output(0, "SERVER: ABORT on %s:%d", procs[0].nspace, procs[0].rank);
+    } else {
+        pmix_output(0, "SERVER: ABORT OF ALL PROCS IN NSPACE %s", proc->nspace);
+    }
+
+    /* instead of aborting the specified procs, notify them
+     * (if they have registered their errhandler) */
+
+    /* use the myxfer_t object to ensure we release
+     * the caller when notification has been queued */
+    x = PMIX_NEW(myxfer_t);
+    (void)strncpy(x->caller.nspace, proc->nspace, PMIX_MAX_NSLEN);
+    x->caller.rank = proc->rank;
+
+    PMIX_INFO_CREATE(x->info, 2);
+    (void)strncpy(x->info[0].key, "DARTH", PMIX_MAX_KEYLEN);
+    x->info[0].value.type = PMIX_INT8;
+    x->info[0].value.data.int8 = 12;
+    (void)strncpy(x->info[1].key, "VADER", PMIX_MAX_KEYLEN);
+    x->info[1].value.type = PMIX_DOUBLE;
+    x->info[1].value.data.dval = 12.34;
+    x->cbfunc = cbfunc;
+    x->cbdata = cbdata;
+
+    if (PMIX_SUCCESS != (rc = PMIx_Notify_event(status, &x->caller,
+                                                PMIX_RANGE_NAMESPACE,
+                                                x->info, 2,
+                                                abcbfunc, x))) {
+        pmix_output(0, "SERVER: FAILED NOTIFY ERROR %d", (int)rc);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+
+static pmix_status_t fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
+                      const pmix_info_t info[], size_t ninfo,
+                      char *data, size_t ndata,
+                      pmix_modex_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_output(0, "SERVER: FENCENB");
+    /* pass the provided data back to each participating proc */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, data, ndata, cbdata, NULL, NULL);
+    }
+    return PMIX_SUCCESS;
+}
+
+
+static pmix_status_t dmodex_fn(const pmix_proc_t *proc,
+                     const pmix_info_t info[], size_t ninfo,
+                     pmix_modex_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_output(0, "SERVER: DMODEX");
+
+    /* we don't have any data for remote procs as this
+     * test only runs one server - so report accordingly */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_ERR_NOT_FOUND, NULL, 0, cbdata, NULL, NULL);
+    }
+    return PMIX_SUCCESS;
+}
+
+
+static pmix_status_t publish_fn(const pmix_proc_t *proc,
+                      const pmix_info_t info[], size_t ninfo,
+                      pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_locdat_t *p;
+    size_t n;
+
+    pmix_output(0, "SERVER: PUBLISH");
+
+    for (n=0; n < ninfo; n++) {
+        p = PMIX_NEW(pmix_locdat_t);
+        (void)strncpy(p->pdata.proc.nspace, proc->nspace, PMIX_MAX_NSLEN);
+        p->pdata.proc.rank = proc->rank;
+        (void)strncpy(p->pdata.key, info[n].key, PMIX_MAX_KEYLEN);
+        pmix_value_xfer(&p->pdata.value, (pmix_value_t*)&info[n].value);
+        pmix_list_append(&pubdata, &p->super);
+    }
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+    return PMIX_SUCCESS;
+}
+
+
+static pmix_status_t lookup_fn(const pmix_proc_t *proc, char **keys,
+                     const pmix_info_t info[], size_t ninfo,
+                     pmix_lookup_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_locdat_t *p, *p2;
+    pmix_list_t results;
+    size_t i, n;
+    pmix_pdata_t *pd = NULL;
+    pmix_status_t ret = PMIX_ERR_NOT_FOUND;
+
+    pmix_output(0, "SERVER: LOOKUP");
+
+    PMIX_CONSTRUCT(&results, pmix_list_t);
+
+    for (n=0; NULL != keys[n]; n++) {
+        PMIX_LIST_FOREACH(p, &pubdata, pmix_locdat_t) {
+            if (0 == strncmp(keys[n], p->pdata.key, PMIX_MAX_KEYLEN)) {
+                p2 = PMIX_NEW(pmix_locdat_t);
+                (void)strncpy(p2->pdata.proc.nspace, p->pdata.proc.nspace, PMIX_MAX_NSLEN);
+                p2->pdata.proc.rank = p->pdata.proc.rank;
+                (void)strncpy(p2->pdata.key, p->pdata.key, PMIX_MAX_KEYLEN);
+                pmix_value_xfer(&p2->pdata.value, &p->pdata.value);
+                pmix_list_append(&results, &p2->super);
+                break;
+            }
+        }
+    }
+    if (0 < (n = pmix_list_get_size(&results))) {
+        ret = PMIX_SUCCESS;
+        PMIX_PDATA_CREATE(pd, n);
+        for (i=0; i < n; i++) {
+            p = (pmix_locdat_t*)pmix_list_remove_first(&results);
+            if (p) {
+                (void)strncpy(pd[i].proc.nspace, p->pdata.proc.nspace, PMIX_MAX_NSLEN);
+                pd[i].proc.rank = p->pdata.proc.rank;
+                (void)strncpy(pd[i].key, p->pdata.key, PMIX_MAX_KEYLEN);
+                pmix_value_xfer(&pd[i].value, &p->pdata.value);
+            }
+        }
+    }
+    PMIX_LIST_DESTRUCT(&results);
+    if (NULL != cbfunc) {
+        cbfunc(ret, pd, n, cbdata);
+    }
+    if (0 < n) {
+        PMIX_PDATA_FREE(pd, n);
+    }
+    return PMIX_SUCCESS;
+}
+
+
+static pmix_status_t unpublish_fn(const pmix_proc_t *proc, char **keys,
+                        const pmix_info_t info[], size_t ninfo,
+                        pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_locdat_t *p, *p2;
+    size_t n;
+
+    pmix_output(0, "SERVER: UNPUBLISH");
+
+    for (n=0; NULL != keys[n]; n++) {
+        PMIX_LIST_FOREACH_SAFE(p, p2, &pubdata, pmix_locdat_t) {
+            if (0 == strncmp(keys[n], p->pdata.key, PMIX_MAX_KEYLEN)) {
+                pmix_list_remove_item(&pubdata, &p->super);
+                PMIX_RELEASE(p);
+                break;
+            }
+        }
+    }
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+    return PMIX_SUCCESS;
+}
+
+static void spcbfunc(pmix_status_t status, void *cbdata)
+{
+    myxfer_t *x = (myxfer_t*)cbdata;
+
+    if (NULL != x->spcbfunc) {
+        x->spcbfunc(PMIX_SUCCESS, "DYNSPACE", x->cbdata);
+    }
+}
+
+static pmix_status_t spawn_fn(const pmix_proc_t *proc,
+                    const pmix_info_t job_info[], size_t ninfo,
+                    const pmix_app_t apps[], size_t napps,
+                    pmix_spawn_cbfunc_t cbfunc, void *cbdata)
+{
+    myxfer_t *x;
+
+    pmix_output(0, "SERVER: SPAWN");
+
+    /* in practice, we would pass this request to the local
+     * resource manager for launch, and then have that server
+     * execute our callback function. For now, we will fake
+     * the spawn and just pretend */
+
+    /* must register the nspace for the new procs before
+     * we return to the caller */
+    x = PMIX_NEW(myxfer_t);
+    x->spcbfunc = cbfunc;
+    x->cbdata = cbdata;
+
+    set_namespace(2, "0,1", "DYNSPACE", spcbfunc, x);
+
+    return PMIX_SUCCESS;
+}
+
+
+static pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
+                                const pmix_info_t info[], size_t ninfo,
+                                pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_output(0, "SERVER: CONNECT");
+
+    /* in practice, we would pass this request to the local
+     * resource manager for handling */
+
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+
+static pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
+                                   const pmix_info_t info[], size_t ninfo,
+                                   pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_output(0, "SERVER: DISCONNECT");
+
+    /* in practice, we would pass this request to the local
+     * resource manager for handling */
+
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t register_event_fn(pmix_status_t *codes, size_t ncodes,
+                                       const pmix_info_t info[], size_t ninfo,
+                                       pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t deregister_events(pmix_status_t *codes, size_t ncodes,
+                                       pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t notify_event(pmix_status_t code,
+                                  const pmix_proc_t *source,
+                                  pmix_data_range_t range,
+                                  pmix_info_t info[], size_t ninfo,
+                                  pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    return PMIX_SUCCESS;
+}
+
+typedef struct query_data_t {
+    pmix_info_t *data;
+    size_t ndata;
+} query_data_t;
+
+static pmix_status_t query_fn(pmix_proc_t *proct,
+                              pmix_query_t *queries, size_t nqueries,
+                              pmix_info_cbfunc_t cbfunc,
+                              void *cbdata)
+{
+    size_t n;
+    pmix_info_t *info;
+
+    pmix_output(0, "SERVER: QUERY");
+
+    if (NULL == cbfunc) {
+        return PMIX_ERROR;
+    }
+    /* keep this simple */
+    PMIX_INFO_CREATE(info, nqueries);
+    for (n=0; n < nqueries; n++) {
+        (void)strncpy(info[n].key, queries[n].keys[0], PMIX_MAX_KEYLEN);
+        info[n].value.type = PMIX_STRING;
+        if (0 > asprintf(&info[n].value.data.string, "%d", (int)n)) {
+            return PMIX_ERROR;
+        }
+    }
+    cbfunc(PMIX_SUCCESS, info, nqueries, cbdata, NULL, NULL);
+    return PMIX_SUCCESS;
+}
+
+static void tool_connect_fn(pmix_info_t *info, size_t ninfo,
+                            pmix_tool_connection_cbfunc_t cbfunc,
+                            void *cbdata)
+{
+    pmix_proc_t proc;
+
+    pmix_output(0, "SERVER: TOOL CONNECT");
+
+    /* just pass back an arbitrary nspace */
+    (void)strncpy(proc.nspace, "TOOL", PMIX_MAX_NSLEN);
+    proc.rank = 0;
+
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, &proc, cbdata);
+    }
+}
+
+static void log_fn(const pmix_proc_t *client,
+                   const pmix_info_t data[], size_t ndata,
+                   const pmix_info_t directives[], size_t ndirs,
+                   pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_output(0, "SERVER: LOG");
+
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+}
+
+static void wait_signal_callback(int fd, short event, void *arg)
+{
+    pmix_event_t *sig = (pmix_event_t*) arg;
+    int status;
+    pid_t pid;
+    wait_tracker_t *t2;
+
+    if (SIGCHLD != event_get_signal(sig)) {
+        return;
+    }
+
+    /* we can have multiple children leave but only get one
+     * sigchild callback, so reap all the waitpids until we
+     * don't get anything valid back */
+    while (1) {
+        pid = waitpid(-1, &status, WNOHANG);
+        if (-1 == pid && EINTR == errno) {
+            /* try it again */
+            continue;
+        }
+        /* if we got garbage, then nothing we can do */
+        if (pid <= 0) {
+            return;
+        }
+
+        /* we are already in an event, so it is safe to access the list */
+        PMIX_LIST_FOREACH(t2, &children, wait_tracker_t) {
+            if (pid == t2->pid) {
+                /* found it! */
+                --wakeup;
+                break;
+            }
+        }
+    }
+}

--- a/include/pmix_common.h
+++ b/include/pmix_common.h
@@ -230,6 +230,8 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_NODE_MAP                       "pmix.nmap"             // (char*) regex of nodes containing procs for this job
 #define PMIX_PROC_MAP                       "pmix.pmap"             // (char*) regex describing procs on each node within this job
 #define PMIX_ANL_MAP                        "pmix.anlmap"           // (char*) process mapping in ANL notation (used in PMI-1/PMI-2)
+#define PMIX_APP_MAP_TYPE                   "pmix.apmap.type"       // (char*) type of mapping used to layout the application (e.g., cyclic)
+#define PMIX_APP_MAP_REGEX                  "pmix.apmap.regex"      // (char*) regex describing the result of the mapping
 
 /* attributes used internally to communicate data from the server to the client */
 #define PMIX_PROC_BLOB                      "pmix.pblob"            // (pmix_byte_object_t) packed blob of process data
@@ -310,6 +312,15 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_DEBUG_WAIT_FOR_NOTIFY          "pmix.dbg.notify"        // (bool) block at desired point until receiving debugger release notification
 #define PMIX_DEBUG_JOB                      "pmix.dbg.job"           // (char*) nspace of the job to be debugged - the RM/PMIx server are
 #define PMIX_DEBUG_WAITING_FOR_NOTIFY       "pmix.dbg.waiting"       // (bool) job to be debugged is waiting for a release
+
+/* Resource Manager identification */
+#define PMIX_RM_NAME                        "pmix.rm.name"           // (char*) string name of the resource manager
+#define PMIX_RM_VERSION                     "pmix.rm.version"        // (char*) RM version string
+
+/* attributes for setting envars */
+#define PMIX_SET_ENVAR                      "pmix.set.envar"        // (char*) string "key=value" value shall be put into the environment
+#define PMIX_UNSET_ENVAR                    "pmix.unset.envar"      // (char*) unset envar specified in string
+
 
 /****    PROCESS STATE DEFINITIONS    ****/
 typedef uint8_t pmix_proc_state_t;

--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -483,6 +483,34 @@ pmix_status_t PMIx_server_dmodex_request(const pmix_proc_t *proc,
                                          pmix_dmodex_response_fn_t cbfunc,
                                          void *cbdata);
 
+/* define a callback function for the setup_application API. The returned info
+ * array is owned by the PMIx server library and will be free'd when the
+ * provided cbfunc is called. */
+typedef void (*pmix_setup_application_cbfunc_t)(pmix_status_t status,
+                                                pmix_info_t info[], size_t ninfo,
+                                                void *provided_cbdata,
+                                                pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+/* Provide a function by which the resource manager can request
+ * any application-specific environmental variables prior to
+ * launch of an application. For example, network libraries may
+ * opt to provide security credentials for the application. This
+ * is defined as a non-blocking operation in case network
+ * libraries need to perform some action before responding. The
+ * returned env will be distributed along with the application */
+pmix_status_t PMIx_server_setup_application(const char nspace[],
+                                            pmix_info_t info[], size_t ninfo,
+                                            pmix_setup_application_cbfunc_t cbfunc, void *cbdata);
+
+/* Provide a function by which the local PMIx server can perform
+ * any application-specific operations prior to spawning local
+ * clients of a given application. For example, a network library
+ * might need to setup the local driver for "instant on" addressing.
+ */
+pmix_status_t PMIx_server_setup_local_support(const char nspace[],
+                                              pmix_info_t info[], size_t ninfo,
+                                              pmix_op_cbfunc_t cbfunc, void *cbdata);
+
 #if defined(c_plusplus) || defined(__cplusplus)
 }
 #endif

--- a/src/mca/pnet/Makefile.am
+++ b/src/mca/pnet/Makefile.am
@@ -1,0 +1,44 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+# Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+# Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AM_CPPFLAGS = $(LTDLINCL)
+
+# main library setup
+noinst_LTLIBRARIES = libmca_pnet.la
+libmca_pnet_la_SOURCES =
+
+# local files
+headers = pnet.h
+sources =
+
+# Conditionally install the header files
+if WANT_INSTALL_HEADERS
+pmixdir = $(pmixincludedir)/$(subdir)
+nobase_pmix_HEADERS = $(headers)
+endif
+
+include base/Makefile.include
+
+libmca_pnet_la_SOURCES += $(headers) $(sources)
+
+distclean-local:
+	rm -f base/static-components.h

--- a/src/mca/pnet/base/Makefile.include
+++ b/src/mca/pnet/base/Makefile.include
@@ -1,0 +1,32 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+# Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+# Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# This makefile.am does not stand on its own - it is included from
+# src/Makefile.am
+
+headers += \
+         base/base.h
+
+sources += \
+        base/pnet_base_frame.c \
+        base/pnet_base_select.c \
+        base/pnet_base_fns.c

--- a/src/mca/pnet/base/base.h
+++ b/src/mca/pnet/base/base.h
@@ -21,8 +21,8 @@
  * $HEADER$
  *
  */
-#ifndef PMIX_PSEC_BASE_H_
-#define PMIX_PSEC_BASE_H_
+#ifndef PMIX_PNET_BASE_H_
+#define PMIX_PNET_BASE_H_
 
 #include <src/include/pmix_config.h>
 
@@ -34,11 +34,12 @@
 #include <string.h>
 #endif
 
+#include "src/class/pmix_list.h"
 #include "src/class/pmix_pointer_array.h"
 #include "src/mca/mca.h"
 #include "src/mca/base/pmix_mca_base_framework.h"
 
-#include "src/mca/psec/psec.h"
+#include "src/mca/pnet/pnet.h"
 
 
 BEGIN_C_DECLS
@@ -46,48 +47,44 @@ BEGIN_C_DECLS
 /*
  * MCA Framework
  */
-extern pmix_mca_base_framework_t pmix_psec_base_framework;
+extern pmix_mca_base_framework_t pmix_pnet_base_framework;
 /**
- * PSEC select function
+ * PNET select function
  *
  * Cycle across available components and construct the list
  * of active modules
  */
-pmix_status_t pmix_psec_base_select(void);
+pmix_status_t pmix_pnet_base_select(void);
 
 /**
  * Track an active component / module
  */
-struct pmix_psec_base_active_module_t {
+struct pmix_pnet_base_active_module_t {
     pmix_list_item_t super;
     int pri;
-    pmix_psec_module_t *module;
-    pmix_psec_base_component_t *component;
+    pmix_pnet_module_t *module;
+    pmix_pnet_base_component_t *component;
 };
-typedef struct pmix_psec_base_active_module_t pmix_psec_base_active_module_t;
-PMIX_CLASS_DECLARATION(pmix_psec_base_active_module_t);
+typedef struct pmix_pnet_base_active_module_t pmix_pnet_base_active_module_t;
+PMIX_CLASS_DECLARATION(pmix_pnet_base_active_module_t);
 
 
 /* framework globals */
-struct pmix_psec_globals_t {
+struct pmix_pnet_globals_t {
   pmix_list_t actives;
   bool initialized;
 };
-typedef struct pmix_psec_globals_t pmix_psec_globals_t;
+typedef struct pmix_pnet_globals_t pmix_pnet_globals_t;
 
-extern pmix_psec_globals_t pmix_psec_globals;
+extern pmix_pnet_globals_t pmix_pnet_globals;
 
-PMIX_EXPORT char* pmix_psec_base_get_available_modules(void);
-PMIX_EXPORT pmix_status_t pmix_psec_base_assign_module(struct pmix_peer_t *peer,
-                                                       const char *options);
-PMIX_EXPORT pmix_status_t pmix_psec_base_create_cred(struct pmix_peer_t *peer,
-                                                     pmix_listener_protocol_t protocol,
-                                                     char **cred, size_t *len);
-PMIX_EXPORT pmix_status_t pmix_psec_base_client_handshake(struct pmix_peer_t *peer, int sd);
-PMIX_EXPORT pmix_status_t pmix_psec_base_validate_connection(struct pmix_peer_t *peer,
-                                                             pmix_listener_protocol_t protocol,
-                                                             char *cred, size_t len);
-
+pmix_status_t pmix_pnet_base_setup_app(char *nspace, pmix_list_t *ilist);
+pmix_status_t pmix_pnet_base_setup_local_network(char *nspace,
+                                                 pmix_info_t info[],
+                                                 size_t ninfo);
+pmix_status_t pmix_pnet_base_setup_fork(const pmix_proc_t *peer, char ***env);
+void pmix_pnet_base_child_finalized(pmix_peer_t *peer);
+void pmix_pnet_base_local_app_finalized(char *nspace);
 
 END_C_DECLS
 

--- a/src/mca/pnet/base/pnet_base_fns.c
+++ b/src/mca/pnet/base/pnet_base_fns.c
@@ -1,0 +1,146 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <src/include/pmix_config.h>
+
+#include <pmix_common.h>
+#include "src/include/pmix_globals.h"
+
+#include "src/class/pmix_list.h"
+#include "src/util/error.h"
+
+#include "src/mca/pnet/base/base.h"
+
+
+pmix_status_t pmix_pnet_base_setup_app(char *nspace, pmix_list_t *ilist)
+{
+    pmix_pnet_base_active_module_t *active;
+    pmix_status_t rc;
+
+    if (!pmix_pnet_globals.initialized) {
+        return PMIX_ERR_INIT;
+    }
+
+    /* protect against bozo inputs */
+    if (NULL == nspace || NULL == ilist) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    PMIX_LIST_FOREACH(active, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
+        if (NULL != active->module->setup_app) {
+            if (PMIX_SUCCESS != (rc = active->module->setup_app(nspace, ilist))) {
+                return rc;
+            }
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_pnet_base_setup_local_network(char *nspace,
+                                                 pmix_info_t info[],
+                                                 size_t ninfo)
+{
+    pmix_pnet_base_active_module_t *active;
+    pmix_status_t rc;
+
+    if (!pmix_pnet_globals.initialized) {
+        return PMIX_ERR_INIT;
+    }
+
+    /* protect against bozo inputs */
+    if (NULL == nspace) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    PMIX_LIST_FOREACH(active, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
+        if (NULL != active->module->setup_local_network) {
+            if (PMIX_SUCCESS != (rc = active->module->setup_local_network(nspace, info, ninfo))) {
+                return rc;
+            }
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_pnet_base_setup_fork(const pmix_proc_t *peer, char ***env)
+{
+    pmix_pnet_base_active_module_t *active;
+    pmix_status_t rc;
+
+    if (!pmix_pnet_globals.initialized) {
+        return PMIX_ERR_INIT;
+    }
+
+    /* protect against bozo inputs */
+    if (NULL == peer || NULL == env) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    PMIX_LIST_FOREACH(active, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
+        if (NULL != active->module->setup_fork) {
+            if (PMIX_SUCCESS != (rc = active->module->setup_fork(peer, env))) {
+                return rc;
+            }
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+void pmix_pnet_base_child_finalized(pmix_peer_t *peer)
+{
+    pmix_pnet_base_active_module_t *active;
+
+    if (!pmix_pnet_globals.initialized) {
+        return;
+    }
+
+    /* protect against bozo inputs */
+    if (NULL == peer) {
+        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+        return;
+    }
+
+    PMIX_LIST_FOREACH(active, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
+        if (NULL != active->module->child_finalized) {
+            active->module->child_finalized(peer);
+        }
+    }
+
+    return;
+}
+
+void pmix_pnet_base_local_app_finalized(char *nspace)
+{
+    pmix_pnet_base_active_module_t *active;
+
+    if (!pmix_pnet_globals.initialized) {
+        return;
+    }
+
+    /* protect against bozo inputs */
+    if (NULL == nspace) {
+        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+        return;
+    }
+
+    PMIX_LIST_FOREACH(active, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
+        if (NULL != active->module->local_app_finalized) {
+            active->module->local_app_finalized(nspace);
+        }
+    }
+
+    return;
+}

--- a/src/mca/pnet/base/pnet_base_frame.c
+++ b/src/mca/pnet/base/pnet_base_frame.c
@@ -1,0 +1,93 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2009 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/** @file:
+ *
+ */
+#include <src/include/pmix_config.h>
+
+#include <pmix_common.h>
+
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+
+#include "src/class/pmix_list.h"
+#include "src/mca/base/base.h"
+#include "src/mca/pnet/base/base.h"
+
+/*
+ * The following file was created by configure.  It contains extern
+ * statements and the definition of an array of pointers to each
+ * component's public mca_base_component_t struct.
+ */
+
+#include "src/mca/pnet/base/static-components.h"
+
+/* Instantiate the global vars */
+pmix_pnet_globals_t pmix_pnet_globals = {{{0}}};
+pmix_pnet_module_t pmix_pnet = {
+    .setup_app = pmix_pnet_base_setup_app,
+    .setup_local_network = pmix_pnet_base_setup_local_network,
+    .setup_fork = pmix_pnet_base_setup_fork,
+    .child_finalized = pmix_pnet_base_child_finalized,
+    .local_app_finalized = pmix_pnet_base_local_app_finalized
+};
+
+static pmix_status_t pmix_pnet_close(void)
+{
+  pmix_pnet_base_active_module_t *active, *prev;
+
+    if (!pmix_pnet_globals.initialized) {
+        return PMIX_SUCCESS;
+    }
+    pmix_pnet_globals.initialized = false;
+
+    PMIX_LIST_FOREACH_SAFE(active, prev, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
+      pmix_list_remove_item(&pmix_pnet_globals.actives, &active->super);
+      if (NULL != active->module->finalize) {
+        active->module->finalize();
+      }
+      PMIX_RELEASE(active);
+    }
+    PMIX_DESTRUCT(&pmix_pnet_globals.actives);
+
+    return pmix_mca_base_framework_components_close(&pmix_pnet_base_framework, NULL);
+}
+
+static pmix_status_t pmix_pnet_open(pmix_mca_base_open_flag_t flags)
+{
+    /* initialize globals */
+    pmix_pnet_globals.initialized = true;
+    PMIX_CONSTRUCT(&pmix_pnet_globals.actives, pmix_list_t);
+
+    /* Open up all available components */
+    return pmix_mca_base_framework_components_open(&pmix_pnet_base_framework, flags);
+}
+
+PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, pnet, "PMIx Network Operations",
+                                NULL, pmix_pnet_open, pmix_pnet_close,
+                                mca_pnet_base_static_components, 0);
+
+PMIX_CLASS_INSTANCE(pmix_pnet_base_active_module_t,
+                    pmix_list_item_t,
+                    NULL, NULL);

--- a/src/mca/pnet/base/pnet_base_select.c
+++ b/src/mca/pnet/base/pnet_base_select.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <src/include/pmix_config.h>
+#include <pmix_common.h>
+
+#include <string.h>
+
+#include "src/mca/mca.h"
+#include "src/mca/base/base.h"
+
+#include "src/mca/pnet/base/base.h"
+
+static bool selected = false;
+
+/* Function for selecting a prioritized list of components
+ * from all those that are available. */
+int pmix_pnet_base_select(void)
+{
+    pmix_mca_base_component_list_item_t *cli = NULL;
+    pmix_mca_base_component_t *component = NULL;
+    pmix_mca_base_module_t *module = NULL;
+    pmix_pnet_module_t *nmodule;
+    pmix_pnet_base_active_module_t *newmodule, *mod;
+    int rc, priority;
+    bool inserted;
+
+    if (selected) {
+        /* ensure we don't do this twice */
+        return PMIX_SUCCESS;
+    }
+    selected = true;
+
+    /* Query all available components and ask if they have a module */
+    PMIX_LIST_FOREACH(cli, &pmix_pnet_base_framework.framework_components, pmix_mca_base_component_list_item_t) {
+        component = (pmix_mca_base_component_t *) cli->cli_component;
+
+        pmix_output_verbose(5, pmix_pnet_base_framework.framework_output,
+                            "mca:pnet:select: checking available component %s", component->pmix_mca_component_name);
+
+        /* If there's no query function, skip it */
+        if (NULL == component->pmix_mca_query_component) {
+            pmix_output_verbose(5, pmix_pnet_base_framework.framework_output,
+                                "mca:pnet:select: Skipping component [%s]. It does not implement a query function",
+                                component->pmix_mca_component_name );
+            continue;
+        }
+
+        /* Query the component */
+        pmix_output_verbose(5, pmix_pnet_base_framework.framework_output,
+                            "mca:pnet:select: Querying component [%s]",
+                            component->pmix_mca_component_name);
+        rc = component->pmix_mca_query_component(&module, &priority);
+
+        /* If no module was returned, then skip component */
+        if (PMIX_SUCCESS != rc || NULL == module) {
+            pmix_output_verbose(5, pmix_pnet_base_framework.framework_output,
+                                "mca:pnet:select: Skipping component [%s]. Query failed to return a module",
+                                component->pmix_mca_component_name );
+            continue;
+        }
+
+        /* If we got a module, keep it */
+        nmodule = (pmix_pnet_module_t*) module;
+        /* let it initialize */
+        if (NULL != nmodule->init && PMIX_SUCCESS != nmodule->init()) {
+            continue;
+        }
+        /* add to the list of selected modules */
+        newmodule = PMIX_NEW(pmix_pnet_base_active_module_t);
+        newmodule->pri = priority;
+        newmodule->module = nmodule;
+        newmodule->component = (pmix_pnet_base_component_t*)cli->cli_component;
+
+        /* maintain priority order */
+        inserted = false;
+        PMIX_LIST_FOREACH(mod, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
+            if (priority > mod->pri) {
+                pmix_list_insert_pos(&pmix_pnet_globals.actives,
+                                     (pmix_list_item_t*)mod, &newmodule->super);
+                inserted = true;
+                break;
+            }
+        }
+        if (!inserted) {
+            /* must be lowest priority - add to end */
+            pmix_list_append(&pmix_pnet_globals.actives, &newmodule->super);
+        }
+    }
+
+    if (4 < pmix_output_get_verbosity(pmix_pnet_base_framework.framework_output)) {
+        pmix_output(0, "Final pnet priorities");
+        /* show the prioritized list */
+        PMIX_LIST_FOREACH(mod, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
+            pmix_output(0, "\tpnet: %s Priority: %d", mod->component->base.pmix_mca_component_name, mod->pri);
+        }
+    }
+
+    return PMIX_SUCCESS;;
+}

--- a/src/mca/pnet/opa/Makefile.am
+++ b/src/mca/pnet/opa/Makefile.am
@@ -1,0 +1,54 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+# Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AM_CPPFLAGS = $(pnet_opa_CPPFLAGS)
+
+headers = pnet_opa.h
+sources = \
+        pnet_opa_component.c \
+        pnet_opa.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_pmix_pnet_opa_DSO
+lib =
+lib_sources =
+component = mca_pnet_opa.la
+component_sources = $(headers) $(sources)
+else
+lib = libmca_pnet_opa.la
+lib_sources = $(headers) $(sources)
+component =
+component_sources =
+endif
+
+mcacomponentdir = $(pmixlibdir)
+mcacomponent_LTLIBRARIES = $(component)
+mca_pnet_opa_la_SOURCES = $(component_sources)
+mca_pnet_opa_la_LIBADD = $(pnet_opa_LIBS)
+mca_pnet_opa_la_LDFLAGS = -module -avoid-version $(pnet_opa_LDFLAGS)
+
+noinst_LTLIBRARIES = $(lib)
+libmca_pnet_opa_la_SOURCES = $(lib_sources)
+libmca_pnet_opa_la_LIBADD = $(pnet_opa_LIBS)
+libmca_pnet_opa_la_LDFLAGS = -module -avoid-version $(pnet_opa_LDFLAGS

--- a/src/mca/pnet/opa/configure.m4
+++ b/src/mca/pnet/opa/configure.m4
@@ -1,0 +1,42 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2013      Sandia National Laboratories.  All rights reserved.
+# Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_pnet_opa_CONFIG([action-if-can-compile],
+#                     [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_pmix_pnet_opa_CONFIG],[
+    AC_CONFIG_FILES([src/mca/pnet/opa/Makefile])
+
+    PMIX_CHECK_PSM2([pnet_opa],
+                    [pnet_opa_happy="yes"],
+                    [pnet_opa_happy="no"])
+
+    AS_IF([test "$pnet_opa_happy" = "yes"],
+          [$1],
+          [$2])
+
+    # substitute in the things needed to build psm2
+    AC_SUBST([pnet_opa_CFLAGS])
+    AC_SUBST([pnet_opa_CPPFLAGS])
+    AC_SUBST([pnet_opa_LDFLAGS])
+    AC_SUBST([pnet_opa_LIBS])
+])dnl

--- a/src/mca/pnet/opa/pnet_opa.c
+++ b/src/mca/pnet/opa/pnet_opa.c
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <src/include/pmix_config.h>
+
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+#include <time.h>
+
+#include <pmix_common.h>
+
+#include "src/mca/base/pmix_mca_base_var.h"
+#include "src/include/pmix_socket_errno.h"
+#include "src/include/pmix_globals.h"
+#include "src/class/pmix_list.h"
+#include "src/util/alfg.h"
+#include "src/util/argv.h"
+#include "src/util/error.h"
+#include "src/util/output.h"
+#include "src/util/pmix_environ.h"
+
+#include "src/mca/pnet/pnet.h"
+#include "pnet_opa.h"
+
+static pmix_status_t opa_init(void);
+static void opa_finalize(void);
+static pmix_status_t setup_app(char *nspace, pmix_list_t *ilist);
+static pmix_status_t setup_local_network(char *nspace,
+                                         pmix_info_t info[],
+                                         size_t ninfo);
+static pmix_status_t setup_fork(const pmix_proc_t *peer, char ***env);
+static void child_finalized(pmix_peer_t *peer);
+static void local_app_finalized(char *nspace);
+
+pmix_pnet_module_t pmix_opa_module = {
+    .init = opa_init,
+    .finalize = opa_finalize,
+    .setup_app = setup_app,
+    .setup_local_network = setup_local_network,
+    .setup_fork = setup_fork,
+    .child_finalized = child_finalized,
+    .local_app_finalized = local_app_finalized
+};
+
+static pmix_status_t opa_init(void)
+{
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pnet: opa init");
+    return PMIX_SUCCESS;
+}
+
+static void opa_finalize(void)
+{
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pnet: opa finalize");
+}
+
+/* some network transports require a little bit of information to
+ * "pre-condition" them - i.e., to setup their individual transport
+ * connections so they can generate their endpoint addresses. This
+ * function provides a means for doing so. The resulting info is placed
+ * into the app_context's env array so it will automatically be pushed
+ * into the environment of every MPI process when launched.
+ */
+
+static inline void transports_use_rand(uint64_t* unique_key) {
+    pmix_rng_buff_t rng;
+    pmix_srand(&rng,(unsigned int)time(NULL));
+    unique_key[0] = pmix_rand(&rng);
+    unique_key[1] = pmix_rand(&rng);
+}
+
+static char* transports_print(uint64_t *unique_key)
+{
+    unsigned int *int_ptr;
+    size_t i, j, string_key_len, written_len;
+    char *string_key = NULL, *format = NULL;
+
+    /* string is two 64 bit numbers printed in hex with a dash between
+     * and zero padding.
+     */
+    string_key_len = (sizeof(uint64_t) * 2) * 2 + strlen("-") + 1;
+    string_key = (char*) malloc(string_key_len);
+    if (NULL == string_key) {
+        return NULL;
+    }
+
+    string_key[0] = '\0';
+    written_len = 0;
+
+    /* get a format string based on the length of an unsigned int.  We
+     * want to have zero padding for sizeof(unsigned int) * 2
+     * characters -- when printing as a hex number, each byte is
+     * represented by 2 hex characters.  Format will contain something
+     * that looks like %08lx, where the number 8 might be a different
+     * number if the system has a different sized long (8 would be for
+     * sizeof(int) == 4)).
+     */
+    asprintf(&format, "%%0%dx", (int)(sizeof(unsigned int)) * 2);
+
+    /* print the first number */
+    int_ptr = (unsigned int*) &unique_key[0];
+    for (i = 0 ; i < sizeof(uint64_t) / sizeof(unsigned int) ; ++i) {
+        if (0 == int_ptr[i]) {
+            /* inject some energy */
+            for (j=0; j < sizeof(unsigned int); j++) {
+                int_ptr[i] |= j << j;
+            }
+        }
+        snprintf(string_key + written_len,
+                 string_key_len - written_len,
+                 format, int_ptr[i]);
+        written_len = strlen(string_key);
+    }
+
+    /* print the middle dash */
+    snprintf(string_key + written_len, string_key_len - written_len, "-");
+    written_len = strlen(string_key);
+
+    /* print the second number */
+    int_ptr = (unsigned int*) &unique_key[1];
+    for (i = 0 ; i < sizeof(uint64_t) / sizeof(unsigned int) ; ++i) {
+        if (0 == int_ptr[i]) {
+            /* inject some energy */
+            for (j=0; j < sizeof(unsigned int); j++) {
+                int_ptr[i] |= j << j;
+            }
+        }
+        snprintf(string_key + written_len,
+                 string_key_len - written_len,
+                 format, int_ptr[i]);
+        written_len = strlen(string_key);
+    }
+    free(format);
+
+    return string_key;
+}
+
+static pmix_status_t setup_app(char *nspace, pmix_list_t *ilist)
+{
+    uint64_t unique_key[2];
+    char *string_key, *cs_env;
+    int fd_rand;
+    size_t bytes_read;
+    struct stat buf;
+    pmix_kval_t *kv;
+
+    /* put the number here - or else create an appropriate string. this just needs to
+     * eventually be a string variable
+     */
+    if(0 != stat("/dev/urandom", &buf)) {
+        /* file doesn't exist! */
+        transports_use_rand(unique_key);
+    }
+
+    if(-1 == (fd_rand = open("/dev/urandom", O_RDONLY))) {
+        transports_use_rand(unique_key);
+    } else {
+        bytes_read = read(fd_rand, (char *) unique_key, 16);
+        if(bytes_read != 16) {
+            transports_use_rand(unique_key);
+        }
+        close(fd_rand);
+    }
+
+    if (NULL == (string_key = transports_print(unique_key))) {
+        PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+
+    if (PMIX_SUCCESS != pmix_mca_base_var_env_name("pmix_precondition_transports", &cs_env)) {
+        PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+        free(string_key);
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+
+    kv = PMIX_NEW(pmix_kval_t);
+    if (NULL == kv) {
+        free(string_key);
+        free(cs_env);
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    kv->key = strdup(PMIX_SET_ENVAR);
+    kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+    if (NULL == kv->value) {
+        free(string_key);
+        free(cs_env);
+        PMIX_RELEASE(kv);
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    kv->value->type = PMIX_STRING;
+    if (0 > asprintf(&kv->value->data.string, "%s=%s", cs_env, string_key)) {
+        free(string_key);
+        free(cs_env);
+        PMIX_RELEASE(kv);
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    pmix_list_append(ilist, &kv->super);
+    free(cs_env);
+    free(string_key);
+
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t setup_local_network(char *nspace,
+                                         pmix_info_t info[],
+                                         size_t ninfo)
+{
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t setup_fork(const pmix_proc_t *peer, char ***env)
+{
+    return PMIX_SUCCESS;
+}
+
+static void child_finalized(pmix_peer_t *peer)
+{
+
+}
+
+static void local_app_finalized(char *nspace)
+{
+
+}

--- a/src/mca/pnet/opa/pnet_opa.h
+++ b/src/mca/pnet/opa/pnet_opa.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_PNET_OPA_H
+#define PMIX_PNET_OPA_H
+
+#include <src/include/pmix_config.h>
+
+
+#include "src/mca/pnet/pnet.h"
+
+BEGIN_C_DECLS
+
+/* the component must be visible data for the linker to find it */
+PMIX_EXPORT extern pmix_pnet_base_component_t mca_pnet_opa_component;
+extern pmix_pnet_module_t pmix_opa_module;
+
+END_C_DECLS
+
+#endif

--- a/src/mca/pnet/opa/pnet_opa_component.c
+++ b/src/mca/pnet/opa/pnet_opa_component.c
@@ -1,0 +1,84 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics.  Since linkers generally pull in symbols by object
+ * files, keeping these symbols as the only symbols in this file
+ * prevents utility programs such as "ompi_info" from having to import
+ * entire components just to query their version and parameters.
+ */
+
+#include <src/include/pmix_config.h>
+#include "pmix_common.h"
+
+
+#include "src/mca/pnet/pnet.h"
+#include "pnet_opa.h"
+
+static pmix_status_t component_open(void);
+static pmix_status_t component_close(void);
+static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority);
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+pmix_pnet_base_component_t mca_pnet_opa_component = {
+    .base = {
+        PMIX_PNET_BASE_VERSION_1_0_0,
+
+        /* Component name and version */
+        .pmix_mca_component_name = "opa",
+        PMIX_MCA_BASE_MAKE_VERSION(component,
+                                   PMIX_MAJOR_VERSION,
+                                   PMIX_MINOR_VERSION,
+                                   PMIX_RELEASE_VERSION),
+
+        /* Component open and close functions */
+        .pmix_mca_open_component = component_open,
+        .pmix_mca_close_component = component_close,
+        .pmix_mca_query_component = component_query,
+    },
+    .data = {
+        /* The component is checkpoint ready */
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+    }
+};
+
+
+static int component_open(void)
+{
+    return PMIX_SUCCESS;
+}
+
+
+static int component_query(pmix_mca_base_module_t **module, int *priority)
+{
+    *priority = 10;
+    *module = (pmix_mca_base_module_t *)&pmix_opa_module;
+    return PMIX_SUCCESS;
+}
+
+
+static int component_close(void)
+{
+    return PMIX_SUCCESS;
+}

--- a/src/mca/pnet/pnet.h
+++ b/src/mca/pnet/pnet.h
@@ -1,0 +1,122 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2007-2008 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
+ *
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/**
+ * @file
+ *
+ * This interface is for use by PMIx servers to obtain network-related info
+ * such as security keys that need to be shared across applications, and to
+ * setup network support for applications prior to launch
+ *
+ * Available plugins may be defined at runtime via the typical MCA parameter
+ * syntax.
+ */
+
+#ifndef PMIX_PNET_H
+#define PMIX_PNET_H
+
+#include <src/include/pmix_config.h>
+
+#include "src/class/pmix_list.h"
+#include "src/mca/mca.h"
+#include "src/mca/base/pmix_mca_base_var.h"
+#include "src/mca/base/pmix_mca_base_framework.h"
+#include "src/include/pmix_globals.h"
+
+BEGIN_C_DECLS
+
+/******    MODULE DEFINITION    ******/
+
+/**
+ * Initialize the module. Returns an error if the module cannot
+ * run, success if it can and wants to be used.
+ */
+typedef pmix_status_t (*pmix_pnet_base_module_init_fn_t)(void);
+
+/**
+ * Finalize the module. Tear down any allocated storage, disconnect
+ * from any system support (e.g., LDAP server)
+ */
+typedef void (*pmix_pnet_base_module_fini_fn_t)(void);
+
+/**
+ * Provide an opportunity for the network to define values that
+ * are to be passed to an application. This can include security
+ * tokens required for application processes to communicate with
+ * each other
+ */
+typedef pmix_status_t (*pmix_pnet_base_module_setup_app_fn_t)(char *nspace, pmix_list_t *ilist);
+
+/**
+ * Give the local network library an opportunity to setup address information
+ * for the application by passing in the layout type and a regex describing
+ * the layout */
+typedef pmix_status_t (*pmix_pnet_base_module_setup_local_net_fn_t)(char *nspace,
+                                                                    pmix_info_t info[],
+                                                                    size_t ninfo);
+
+/**
+ * Give the local network library an opportunity to add any envars to the
+ * environment of a local application process prior to fork/exec
+ */
+typedef pmix_status_t (*pmix_pnet_base_module_setup_fork_fn_t)(const pmix_proc_t *peer, char ***env);
+
+/**
+ * Provide an opportunity for the local network library to cleanup when a
+ * local application process terminates
+ */
+typedef void (*pmix_pnet_base_module_child_finalized_fn_t)(pmix_peer_t *peer);
+
+/**
+ * Provide  an opportunity for the local network library to cleanup after
+ * all local clients for a given application have terminated
+ */
+typedef void (*pmix_pnet_base_module_local_app_finalized_fn_t)(char *nspace);
+
+/**
+ * Base structure for a PNET module
+ */
+typedef struct {
+    char *name;
+    /* init/finalize */
+    pmix_pnet_base_module_init_fn_t                 init;
+    pmix_pnet_base_module_fini_fn_t                 finalize;
+    pmix_pnet_base_module_setup_app_fn_t            setup_app;
+    pmix_pnet_base_module_setup_local_net_fn_t      setup_local_network;
+    pmix_pnet_base_module_setup_fork_fn_t           setup_fork;
+    pmix_pnet_base_module_child_finalized_fn_t      child_finalized;
+    pmix_pnet_base_module_local_app_finalized_fn_t  local_app_finalized;
+} pmix_pnet_module_t;
+
+/* declare the global APIs */
+PMIX_EXPORT extern pmix_pnet_module_t pmix_pnet;
+
+/*
+ * the standard component data structure
+ */
+struct pmix_pnet_base_component_t {
+    pmix_mca_base_component_t                        base;
+    pmix_mca_base_component_data_t                   data;
+};
+typedef struct pmix_pnet_base_component_t pmix_pnet_base_component_t;
+
+/*
+ * Macro for use in components that are of type pnet
+ */
+#define PMIX_PNET_BASE_VERSION_1_0_0 \
+    PMIX_MCA_BASE_VERSION_1_0_0("pnet", 1, 0, 0)
+
+END_C_DECLS
+
+#endif

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -144,7 +144,6 @@ static void lost_connection(pmix_peer_t *peer, pmix_status_t err)
 
 static pmix_status_t send_msg(int sd, pmix_ptl_send_t *msg)
 {
-    pmix_status_t ret = PMIX_SUCCESS;
     struct iovec iov[2];
     int iov_count;
     ssize_t remain = msg->sdbytes, rc;

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -35,6 +35,7 @@
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/pif/base/base.h"
 #include "src/mca/pinstalldirs/base/base.h"
+#include "src/mca/pnet/base/base.h"
 #include "src/mca/psec/base/base.h"
 #include "src/mca/ptl/base/base.h"
 #include "src/dstore/pmix_dstore.h"
@@ -80,6 +81,9 @@ void pmix_rte_finalize(void)
 
     /* close the security framework */
     (void)pmix_mca_base_framework_close(&pmix_psec_base_framework);
+
+    /* close the pnet framework */
+    (void)pmix_mca_base_framework_close(&pmix_pnet_base_framework);
 
     /* finalize the mca */
     /* Clear out all the registered MCA params */

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -43,6 +43,7 @@
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/pif/base/base.h"
 #include "src/mca/pinstalldirs/base/base.h"
+#include "src/mca/pnet/base/base.h"
 #include "src/mca/psec/base/base.h"
 #include "src/mca/ptl/base/base.h"
 
@@ -212,6 +213,16 @@ int pmix_rte_init(pmix_proc_type_t type,
     if (PMIX_SUCCESS != (ret = pmix_mca_base_framework_open(&pmix_pif_base_framework, 0))) {
         error = "pmix_pif_base_open";
         return ret;
+    }
+
+    /* open the pnet and select the active modules for this environment */
+    if (PMIX_SUCCESS != (ret = pmix_mca_base_framework_open(&pmix_pnet_base_framework, 0))) {
+        error = "pmix_pnet_base_open";
+        goto return_error;
+    }
+    if (PMIX_SUCCESS != (ret = pmix_pnet_base_select())) {
+        error = "pmix_pnet_base_select";
+        goto return_error;
     }
 
     /* tell libevent that we need thread support */

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -59,6 +59,7 @@
 #include "src/mca/base/base.h"
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/pinstalldirs/base/base.h"
+#include "src/mca/pnet/pnet.h"
 #include "src/runtime/pmix_progress_threads.h"
 #include "src/runtime/pmix_rte.h"
 #include "src/mca/ptl/base/base.h"
@@ -533,6 +534,10 @@ static void _deregister_nspace(int sd, short args, void *cbdata)
     rc = pmix_dstore_nspace_del(cd->proc.nspace);
 #endif
 
+    /* release any job-level resources */
+    pmix_pnet.local_app_finalized(cd->proc.nspace);
+
+    /* release the caller */
     if (NULL != cd->opcbfunc) {
         cd->opcbfunc(rc, cd->cbdata);
     }
@@ -845,9 +850,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_setup_fork(const pmix_proc_t *proc, char *
 {
     char rankstr[128];
     pmix_listener_t *lt;
-#if defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1)
     pmix_status_t rc;
-#endif
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix:server setup_fork for nspace %s rank %d",
@@ -876,6 +879,12 @@ PMIX_EXPORT pmix_status_t PMIx_server_setup_fork(const pmix_proc_t *proc, char *
         return rc;
     }
 #endif
+
+    /* get any network contribution */
+    if (PMIX_SUCCESS != (rc = pmix_pnet.setup_fork(proc, env))) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
 
     return PMIX_SUCCESS;
 }
@@ -1420,6 +1429,139 @@ PMIX_EXPORT pmix_status_t PMIx_generate_ppn(const char *input, char **regexp)
     PMIX_LIST_DESTRUCT(&nodes);
     return PMIX_SUCCESS;
 }
+
+static void _setup_op(pmix_status_t rc, void *cbdata)
+{
+    pmix_setup_caddy_t *fcd = (pmix_setup_caddy_t*)cbdata;
+
+    if (NULL != fcd->info) {
+        PMIX_INFO_FREE(fcd->info, fcd->ninfo);
+    }
+    PMIX_RELEASE(fcd);
+}
+
+static void _setup_app(int sd, short args, void *cbdata)
+{
+    pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
+    pmix_setup_caddy_t *fcd = NULL;
+    pmix_status_t rc;
+    pmix_list_t ilist;
+    pmix_kval_t *kv;
+    size_t n;
+
+    PMIX_CONSTRUCT(&ilist, pmix_list_t);
+
+    /* pass to the network libraries */
+    if (PMIX_SUCCESS != (rc = pmix_pnet.setup_app(cd->nspace, &ilist))) {
+        goto depart;
+    }
+
+    /* setup the return callback */
+    fcd = PMIX_NEW(pmix_setup_caddy_t);
+    if (NULL == fcd) {
+        rc = PMIX_ERR_NOMEM;
+        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+        goto depart;
+    }
+
+    /* if anything came back, construct the info array */
+    if (0 < (fcd->ninfo = pmix_list_get_size(&ilist))) {
+        PMIX_INFO_CREATE(fcd->info, fcd->ninfo);
+        n = 0;
+        PMIX_LIST_FOREACH(kv, &ilist, pmix_kval_t) {
+            (void)strncpy(fcd->info[n].key, kv->key, PMIX_MAX_KEYLEN);
+            if (PMIX_SUCCESS != (rc = pmix_value_xfer(&fcd->info[n].value, kv->value))) {
+                PMIX_INFO_FREE(fcd->info, fcd->ninfo);
+                PMIX_RELEASE(fcd);
+                fcd = NULL;
+                goto depart;
+            }
+        }
+    }
+
+  depart:
+    /* always execute the callback to avoid hanging */
+    if (NULL != cd->setupcbfunc) {
+        if (NULL == fcd) {
+            cd->setupcbfunc(rc, NULL, 0, cd->cbdata, NULL, NULL);
+        } else {
+            cd->setupcbfunc(rc, fcd->info, fcd->ninfo, cd->cbdata, _setup_op, fcd);
+        }
+    }
+
+    /* cleanup memory */
+    PMIX_LIST_DESTRUCT(&ilist);
+    if (NULL != cd->nspace) {
+        free(cd->nspace);
+    }
+    PMIX_RELEASE(cd);
+}
+
+pmix_status_t PMIx_server_setup_application(const char nspace[],
+                                            pmix_info_t info[], size_t ninfo,
+                                            pmix_setup_application_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_setup_caddy_t *cd;
+
+    /* need to threadshift this request */
+    cd = PMIX_NEW(pmix_setup_caddy_t);
+    if (NULL == cd) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (NULL != nspace) {
+        cd->nspace = strdup(nspace);
+    }
+    cd->info = info;
+    cd->ninfo = ninfo;
+    cd->setupcbfunc = cbfunc;
+    cd->cbdata = cbdata;
+    PMIX_THREADSHIFT(cd, _setup_app);
+
+    return PMIX_SUCCESS;
+}
+
+static void _setup_local_support(int sd, short args, void *cbdata)
+{
+    pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
+    pmix_status_t rc;
+
+    /* pass to the network libraries */
+    rc = pmix_pnet.setup_local_network(cd->nspace, cd->info, cd->ninfo);
+
+    /* pass the info back */
+    if (NULL != cd->opcbfunc) {
+        cd->opcbfunc(rc, cd->cbdata);
+    }
+    /* cleanup memory */
+    if (NULL != cd->nspace) {
+        free(cd->nspace);
+    }
+    PMIX_RELEASE(cd);
+}
+
+pmix_status_t PMIx_server_setup_local_support(const char nspace[],
+                                              pmix_info_t info[], size_t ninfo,
+                                              pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_setup_caddy_t *cd;
+
+    /* need to threadshift this request */
+    cd = PMIX_NEW(pmix_setup_caddy_t);
+    if (NULL == cd) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (NULL != nspace) {
+        cd->nspace = strdup(nspace);
+    }
+    cd->info = info;
+    cd->ninfo = ninfo;
+    cd->opcbfunc = cbfunc;
+    cd->cbdata = cbdata;
+    PMIX_THREADSHIFT(cd, _setup_local_support);
+
+    return PMIX_SUCCESS;
+}
+
 
 /****    THE FOLLOWING CALLBACK FUNCTIONS ARE USED BY THE HOST SERVER    ****
  ****    THEY THEREFORE CAN OCCUR IN EITHER THE HOST SERVER'S THREAD     ****
@@ -2093,6 +2235,8 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag,
             event_del(&peer->recv_event);
             peer->recv_ev_active = false;
         }
+        /* let the network libraries cleanup */
+        pmix_pnet.child_finalized(peer);
         return rc;
     }
 

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1555,11 +1555,14 @@ static void scadcon(pmix_setup_caddy_t *p)
 {
     memset(&p->proc, 0, sizeof(pmix_proc_t));
     p->active = true;
+    p->nspace = NULL;
     p->server_object = NULL;
     p->nlocalprocs = 0;
     p->info = NULL;
     p->ninfo = 0;
     p->cbfunc = NULL;
+    p->opcbfunc = NULL;
+    p->setupcbfunc = NULL;
     p->cbdata = NULL;
 }
 static void scaddes(pmix_setup_caddy_t *p)

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -32,6 +32,7 @@ typedef struct {
     pmix_object_t super;
     pmix_event_t ev;
     volatile bool active;
+    char *nspace;
     pmix_status_t status;
     pmix_proc_t proc;
     uid_t uid;
@@ -42,6 +43,7 @@ typedef struct {
     size_t ninfo;
     pmix_op_cbfunc_t opcbfunc;
     pmix_dmodex_response_fn_t cbfunc;
+    pmix_setup_application_cbfunc_t setupcbfunc;
     void *cbdata;
 } pmix_setup_caddy_t;
 PMIX_CLASS_DECLARATION(pmix_setup_caddy_t);

--- a/src/util/Makefile.include
+++ b/src/util/Makefile.include
@@ -28,6 +28,7 @@ LEX_OUTPUT_ROOT = lex.pmix_show_help_yy
 # Source code files
 
 headers += \
+        util/alfg.h \
         util/argv.h \
         util/error.h \
         util/printf.h \
@@ -52,6 +53,7 @@ headers += \
         util/compress.h
 
 sources += \
+        util/alfg.c \
         util/argv.c \
         util/error.c \
         util/printf.c \

--- a/src/util/alfg.c
+++ b/src/util/alfg.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2014      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <src/include/pmix_config.h>
+
+#include <string.h>
+
+#include "alfg.h"
+
+/* Mask corresponding to the primitive polynomial
+ *---------------------------------------------------
+ *
+ * p(x) = 1 + x^25 + x^27 + x^29 + x^30 + x^31 + x^32
+ *
+ *---------------------------------------------------
+ */
+#define MASK 0x80000057U
+
+/* Additive lagged Fibonacci parameters:
+ *---------------------------------------------------
+ *
+ * x_n = (x_(n - TAP1) + x_(n - TAP2) ) mod M
+ *
+ *---------------------------------------------------
+ */
+#define TAP1 127
+#define TAP2 97
+#define CBIT 21  /* Canonical bit */
+
+
+/**
+ * @brief      Galois shift register: Used to seed the ALFG's
+ *             canonical rectangle
+ *
+ * @param[in]  unsigned int *seed: used to seed the Galois register
+ * @param[out] uint32_t lsb: least significant bit of the Galois
+ *             register after shift
+ */
+static uint32_t galois(unsigned int *seed){
+
+    uint32_t lsb;
+    lsb = (*seed & 1) ? 1 : 0;
+    *seed >>= 1;
+    /* tap it with the mask */
+    *seed = *seed ^ (lsb*MASK);
+
+    return lsb;
+}
+
+/* PMIX global rng buffer */
+static pmix_rng_buff_t alfg_buffer;
+
+/**
+ * @brief   Routine to seed the ALFG register
+ *
+ * @param[in]   uint32_t seed
+ * @param[out]  pmix_rng_buff_t *buff: handle to ALFG buffer state
+ */
+int pmix_srand(pmix_rng_buff_t *buff, uint32_t seed) {
+
+    int i, j;
+    uint32_t seed_cpy = seed;
+    buff->tap1 = TAP1 - 1;
+    buff->tap2 = TAP2 - 1;
+
+    /* zero out the register */
+    for( i = 0; i < TAP1; i++){
+        buff->alfg[i] = 0;
+    }
+    /* set the canonical bit */
+    buff->alfg[CBIT] = 1;
+
+    /* seed the ALFG register by blasting
+     * the canonical rectangle with bits
+    */
+    for ( j = 1; j < TAP1; j++){
+        for( i = 1; i < 32; i++){
+            buff->alfg[j] = buff->alfg[j] ^ ((galois(&seed_cpy))<<i);
+        }
+    }
+    /* copy the ALFG to the global buffer */
+    memcpy(&alfg_buffer, buff, sizeof(alfg_buffer));
+
+    return 1;
+
+}
+
+/**
+ * @brief       The additive lagged Fibonnaci PRNG
+ *
+ * @param[in]   pmix_rng_buff_t *buff: handle to ALFG buffer state
+ * @param[out]  32-bit unsigned random integer
+ */
+
+uint32_t pmix_rand(pmix_rng_buff_t *buff){
+
+    int *tap1 = &(buff->tap1);
+    int *tap2 = &(buff->tap2);
+    uint64_t overflow;
+    uint32_t temp;
+
+    /* prevent overflow */
+    overflow = (uint64_t) buff->alfg[*tap1] + (uint64_t) buff->alfg[*tap2];
+    /* circular buffer arithmetic */
+    temp = (*tap1 + 1) == TAP1 ?  0 :  (*tap1 + 1);
+    /* Division modulo 2^32 */
+    buff->alfg[temp] = (uint32_t) ( overflow & ((1ULL<<32) -1));
+
+    /* increment tap points */
+    *tap1 = (*tap1 + 1)%TAP1;
+    *tap2 = (*tap2 + 1)%TAP1;
+
+    return buff->alfg[temp];
+
+}
+
+/**
+ * @brief      A wrapper for pmix_rand() with our global ALFG buffer;
+ *
+ * @param[in]  none
+ * @param[out] int, the same as normal rand(3)
+ */
+int pmix_random(void){
+    /* always return a positive int */
+    return (int)(pmix_rand(&alfg_buffer) & 0x7FFFFFFF);
+}

--- a/src/util/alfg.h
+++ b/src/util/alfg.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2014      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_ALFG_H
+#define PMIX_ALFG_H
+
+#include <src/include/pmix_config.h>
+
+#include "pmix_stdint.h"
+
+
+struct pmix_rng_buff_t {
+    uint32_t alfg[127];
+    int tap1;
+    int tap2;
+};
+typedef struct pmix_rng_buff_t pmix_rng_buff_t;
+
+
+/* NOTE: UNLIKE OTHER PMIX FUNCTIONS, THIS FUNCTION RETURNS A 1 IF
+ * SUCCESSFUL INSTEAD OF PMIX_SUCCESS */
+PMIX_EXPORT int pmix_srand(pmix_rng_buff_t *buff, uint32_t seed);
+
+PMIX_EXPORT uint32_t pmix_rand(pmix_rng_buff_t *buff);
+
+PMIX_EXPORT int pmix_random(void);
+
+#endif /* PMIX_ALFG_H */


### PR DESCRIPTION
Add a new network support framework so that the RM can:

* precondition an application (e.g., adding a security token to the app's environment)

* setup the local network driver to support an application (e.g., for "instant on" address resolution)

* pass directives in the environment of client procs prior to forking

* cleanup after each child terminates

* cleanup after all local children for a given application have terminated

Signed-off-by: Ralph Castain <rhc@open-mpi.org>