### PR TITLE
Add missing header to Makefile.am so it is included in the tarball

### DIFF
--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -23,7 +23,8 @@
 # src/Makefile.am
 
 headers += \
-        src/include/pmix_globals.h
+        src/include/pmix_globals.h \
+        src/include/pmix_jobdata.h
 
 sources += \
         src/include/pmix_globals.c


### PR DESCRIPTION
Signed-off-by: Ralph Castain <rhc@open-mpi.org>