### PR TITLE
Add flags to direct PMIx to only use one listener, but without direct…

### DIFF
--- a/include/pmix_common.h
+++ b/include/pmix_common.h
@@ -134,6 +134,8 @@ typedef uint32_t pmix_rank_t;
 /* attributes for the USOCK rendezvous socket  */
 #define PMIX_USOCK_DISABLE                  "pmix.usock.disable"    // (bool) disable legacy usock support
 #define PMIX_SOCKET_MODE                    "pmix.sockmode"         // (uint32_t) POSIX mode_t (9 bits valid)
+#define PMIX_SINGLE_LISTENER                "pmix.sing.listnr"      // (bool) use only one rendezvous socket, letting priorities and/or
+                                                                    //        MCA param select the active transport
 
 /* attributes for TCP connections */
 #define PMIX_TCP_URI                        "pmix.tcp.uri"          // (char*) URI of server to connect to


### PR DESCRIPTION
…ing which one (tcp or usock) to use. This allows the user to set PMIX_MCA_ptl in their environment to select the transport method.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>