### PR TITLE
Remove some debug output from configury, and ensure we can provide an…

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -17,7 +17,7 @@ dnl Copyright (c) 2009      Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2011-2013 NVIDIA Corporation.  All rights reserved.
-dnl Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2015-2016 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -90,7 +90,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     if test "$?" != "0"; then
         AC_MSG_ERROR([Cannot continue])
     fi
-    AC_MSG_RESULT([$PMIX_MAJOR_VERSION])
     AC_SUBST(PMIX_MAJOR_VERSION)
     AC_DEFINE_UNQUOTED([PMIX_MAJOR_VERSION], [$PMIX_MAJOR_VERSION],
                        [The library major version is always available, contrary to VERSION])
@@ -99,7 +98,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     if test "$?" != "0"; then
         AC_MSG_ERROR([Cannot continue])
     fi
-    AC_MSG_RESULT([$PMIX_MINOR_VERSION])
     AC_SUBST(PMIX_MINOR_VERSION)
     AC_DEFINE_UNQUOTED([PMIX_MINOR_VERSION], [$PMIX_MINOR_VERSION],
                        [The library minor version is always available, contrary to VERSION])
@@ -114,7 +112,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     if test "$?" != "0"; then
         AC_MSG_ERROR([Cannot continue])
     fi
-    AC_MSG_RESULT([$PMIX_RELEASE_VERSION])
     AC_SUBST(PMIX_RELEASE_VERSION)
     AC_DEFINE_UNQUOTED([PMIX_RELEASE_VERSION], [$PMIX_RELEASE_VERSION],
                        [The library release version is always available, contrary to VERSION])
@@ -679,9 +676,9 @@ AC_DEFUN([PMIX_SETUP_CORE],[
         # rather than have successive assignments to these shell
         # variables, lest the $(foo) names try to get evaluated here.
         # Yuck!
-        CPPFLAGS='-I$(PMIX_top_builddir) -I$(PMIX_top_srcdir) -I$(PMIX_top_srcdir)/src -I$(PMIX_top_builddir)/include -I$(PMIX_top_srcdir)/include'" $CPPFLAGS"
+        CPPFLAGS="-I$PMIX_top_builddir -I$PMIX_top_srcdir -I$PMIX_top_srcdir/src -I$PMIX_top_builddir/include -I$PMIX_top_srcdir/include $CPPFLAGS"
     else
-        CPPFLAGS='-I$(PMIX_top_srcdir) -I$(PMIX_top_srcdir)/src -I$(PMIX_top_srcdir)/include'" $CPPFLAGS"
+        CPPFLAGS="-I$PMIX_top_srcdir -I$PMIX_top_srcdir/src -I$PMIX_top_srcdir/include $CPPFLAGS"
     fi
 
     # pmixdatadir, pmixlibdir, and pmixinclude are essentially the same as
@@ -707,6 +704,11 @@ AC_DEFUN([PMIX_SETUP_CORE],[
         pmix_config_prefix[src/util/keyval/Makefile]
         pmix_config_prefix[src/mca/base/Makefile]
         )
+
+    # publish any embedded flags so external wrappers can use them
+    AC_SUBST(PMIX_EMBEDDED_LIBS)
+    AC_SUBST(PMIX_EMBEDDED_LDFLAGS)
+    AC_SUBST(PMIX_EMBEDDED_CPPFLAGS)
 
     # Success
     $2

--- a/config/pmix_setup_zlib.m4
+++ b/config/pmix_setup_zlib.m4
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
-# Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+# Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -58,10 +58,13 @@ AC_DEFUN([PMIX_ZLIB_CONFIG],[
                            [pmix_zlib_support=0])
         if test $pmix_zlib_support == "1"; then
             LIBS="$LIBS -lz"
+            PMIX_EMBEDDED_LIBS="$PMIX_EMBEDDED_LIBS -lz"
             if test "$pmix_zlib_standard_header_location" != "yes"; then
+                PMIX_EMBEDDED_CPPFLAGS="$PMIX_EMBEDDED_CPPFLAGS $pmix_zlib_CPPFLAGS"
                 CPPFLAGS="$CPPFLAGS $pmix_zlib_CPPFLAGS"
             fi
             if test "$pmix_zlib_standard_lib_location" != "yes"; then
+                PMIX_EMBEDDED_LDFLAGS="$PMIX_EMBEDDED_LDFLAGS $pmix_zlib_LDFLAGS"
                 LDFLAGS="$LDFLAGS $pmix_zlib_LDFLAGS"
             fi
         fi


### PR DESCRIPTION
…y externally required libs to an embedding package so they can include them in their wrapper compilers

Signed-off-by: Ralph Castain <rhc@open-mpi.org>