### PR TITLE
pmix/test: add key replacement and internal store

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -25,7 +25,9 @@ if !WANT_HIDDEN
 SUBDIRS = simple
 endif
 
-headers = test_common.h cli_stages.h server_callbacks.h utils.h test_fence.h test_publish.h test_spawn.h test_cd.h test_resolve_peers.h test_error.h
+headers = test_common.h cli_stages.h server_callbacks.h utils.h test_fence.h \
+        test_publish.h test_spawn.h test_cd.h test_resolve_peers.h test_error.h \
+        test_replace.h test_internal.h
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/src/api
 
@@ -54,7 +56,8 @@ pmi2_client_LDADD = \
     $(top_builddir)/src/libpmix.la
 
 pmix_client_SOURCES = $(headers) \
-        pmix_client.c test_fence.c test_common.c test_publish.c test_spawn.c test_cd.c test_resolve_peers.c test_error.c
+        pmix_client.c test_fence.c test_common.c test_publish.c test_spawn.c \
+        test_cd.c test_resolve_peers.c test_error.c test_replace.c test_internal.c
 pmix_client_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 pmix_client_LDADD = \
     $(top_builddir)/src/libpmix.la

--- a/test/pmix_client.c
+++ b/test/pmix_client.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
- * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -39,7 +39,8 @@
 #include "test_cd.h"
 #include "test_resolve_peers.h"
 #include "test_error.h"
-
+#include "test_replace.h"
+#include "test_internal.h"
 
 static void errhandler(size_t evhdlr_registration_id,
                        pmix_status_t status,
@@ -190,6 +191,24 @@ int main(int argc, char **argv)
         if (PMIX_SUCCESS != rc) {
             FREE_TEST_PARAMS(params);
             TEST_ERROR(("%s:%d error registration and event handling test failed: %d", myproc.nspace, myproc.rank, rc));
+            exit(0);
+        }
+    }
+
+    if (NULL != params.key_replace) {
+        rc = test_replace(myproc.nspace, myproc.rank, params);
+        if (PMIX_SUCCESS != rc) {
+            FREE_TEST_PARAMS(params);
+            TEST_ERROR(("%s:%d error key replace test failed: %d", myproc.nspace, myproc.rank, rc));
+            exit(0);
+        }
+    }
+
+    if (params.test_internal) {
+        rc = test_internal(myproc.nspace, myproc.rank, params);
+        if (PMIX_SUCCESS != rc) {
+            FREE_TEST_PARAMS(params);
+            TEST_ERROR(("%s:%d error key store internal test failed: %d", myproc.nspace, myproc.rank, rc));
             exit(0);
         }
     }

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
- * Copyright (c) 2015      Mellanox Technologies, Inc.
+ * Copyright (c) 2015-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
  *
@@ -18,6 +18,7 @@
 #include "test_common.h"
 #include <stdarg.h>
 #include <stdio.h>
+#include <ctype.h>
 
 int pmix_test_verbose = 0;
 
@@ -76,7 +77,9 @@ void parse_cmd(int argc, char **argv, test_params *params)
             fprintf(stderr, "\t--test-spawn       test spawn api.\n");
             fprintf(stderr, "\t--test-connect     test connect/disconnect api.\n");
             fprintf(stderr, "\t--test-resolve-peers    test resolve_peers api.\n");
-            fprintf(stderr, "t--test-error test error handling api.\n");
+            fprintf(stderr, "\t--test-error test error handling api.\n");
+            fprintf(stderr, "\t--test-replace N:k0,k1,...,k(N-1)   test key replace for N keys, k0,k1,k(N-1) - key indexes to replace  \n");
+            fprintf(stderr, "\t--test-internal N  test store internal key, N - number of internal keys\n");
             exit(0);
         } else if (0 == strcmp(argv[i], "--exec") || 0 == strcmp(argv[i], "-e")) {
             i++;
@@ -169,6 +172,24 @@ void parse_cmd(int argc, char **argv, test_params *params)
             params->test_resolve_peers = 1;
         } else if( 0 == strcmp(argv[i], "--test-error") ){
             params->test_error = 1;
+        } else if(0 == strcmp(argv[i], "--test-replace") ) {
+            i++;
+            if (NULL != argv[i] && (*argv[i] != '-')) {
+                params->key_replace = strdup(argv[i]);
+                if (0 != parse_replace(params->key_replace, 0, NULL)) {
+                    fprintf(stderr, "Incorrect --test-replace option format: %s\n", params->key_replace);
+                    exit(1);
+                }
+            } else {
+                params->key_replace = strdup(TEST_REPLACE_DEFAULT);
+            }
+        } else if(0 == strcmp(argv[i], "--test-internal")) {
+            i++;
+            if ((NULL != argv[i]) && (*argv[i] != '-')) {
+                params->test_internal = strtol(argv[i], NULL, 10);
+            } else {
+                params->test_internal = 1;
+            }
         }
 
         else {
@@ -256,11 +277,16 @@ PMIX_CLASS_INSTANCE(participant_t,
                     pmix_list_item_t,
                     NULL, NULL);
 
+PMIX_CLASS_INSTANCE(key_replace_t,
+                    pmix_list_item_t,
+                    NULL, NULL);
+
 static int ns_id = -1;
 static fence_desc_t *fdesc = NULL;
 pmix_list_t *participants = NULL;
 pmix_list_t test_fences;
 pmix_list_t *noise_range = NULL;
+pmix_list_t key_replace;
 
 #define CHECK_STRTOL_VAL(val, str, store) do {                  \
     if (0 == val) {                                             \
@@ -479,6 +505,67 @@ int parse_noise(char *noise_param, int store)
             }
         } else {
             ret = 1;
+        }
+    }
+    free(tmp);
+    return ret;
+}
+
+static int is_digit(const char *str)
+{
+    if (NULL == str)
+        return 0;
+
+    while (0 != *str) {
+        if (!isdigit(*str)) {
+        return 0;
+        }
+        else {
+            str++;
+        }
+    }
+    return 1;
+}
+
+int parse_replace(char *replace_param, int store, int *key_num) {
+    int ret = 0;
+    char *tmp = strdup(replace_param);
+    char tmp_str[32];
+    char * pch, *ech;
+    key_replace_t *item;
+    int cnt = 0;
+
+    if (NULL == replace_param) {
+        free(tmp);
+        return 1;
+    }
+
+    pch = strchr(tmp, ':');
+    snprintf(tmp_str, pch - tmp + 1, "%s", tmp);
+    cnt = atol(tmp_str);
+
+    if (NULL != key_num) {
+        *key_num = cnt;
+    }
+
+    while(NULL != pch) {
+        pch++;
+        ech = strchr(pch, ',');
+        if (NULL != ech || (strlen(pch) > 0)) {
+            snprintf(tmp_str, ech - pch + 1, "%s", pch);
+            if ((0 == is_digit(tmp_str)) || ((atoi(tmp_str) + 1) > cnt)) {
+                ret = 1;
+                break;
+            }
+            pch = ech;
+            if (store) {
+                item = PMIX_NEW(key_replace_t);
+                item->key_idx = atoi(tmp_str);
+                pmix_list_append(&key_replace, &item->super);
+            }
+        } else {
+            ret = 1;
+            break;
         }
     }
     free(tmp);

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -4,7 +4,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2015      Mellanox Technologies, Inc.
+ * Copyright (c) 2015-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
  *
@@ -72,6 +72,7 @@ extern FILE *file;
 
 #define TEST_DEFAULT_TIMEOUT 10
 #define MAX_DIGIT_LEN 10
+#define TEST_REPLACE_DEFAULT "3:1"
 
 #define TEST_SET_FILE(prefix, ns_id, rank) { \
     char *fname = malloc( strlen(prefix) + MAX_DIGIT_LEN + 2 ); \
@@ -116,6 +117,8 @@ typedef struct {
     int test_connect;
     int test_resolve_peers;
     int test_error;
+    char *key_replace;
+    int test_internal;
 } test_params;
 
 #define INIT_TEST_PARAMS(params) do { \
@@ -144,6 +147,8 @@ typedef struct {
     params.noise = NULL;              \
     params.ns_dist = NULL;            \
     params.test_error = 0;            \
+    params.key_replace = NULL;        \
+    params.test_internal = 0;         \
 } while (0)
 
 #define FREE_TEST_PARAMS(params) do { \
@@ -173,6 +178,7 @@ typedef struct {
 void parse_cmd(int argc, char **argv, test_params *params);
 int parse_fence(char *fence_param, int store);
 int parse_noise(char *noise_param, int store);
+int parse_replace(char *replace_param, int store, int *key_num);
 
 typedef struct {
     pmix_list_item_t super;
@@ -188,11 +194,140 @@ typedef struct {
 } participant_t;
 PMIX_CLASS_DECLARATION(participant_t);
 
+typedef struct {
+    pmix_list_item_t super;
+    int key_idx;
+} key_replace_t;
+PMIX_CLASS_DECLARATION(key_replace_t);
+
 extern pmix_list_t test_fences;
 extern pmix_list_t *noise_range;
+extern pmix_list_t key_replace;
 
 #define NODE_NAME "node1"
 int get_total_ns_number(test_params params);
 int get_all_ranks_from_namespace(test_params params, char *nspace, pmix_proc_t **ranks, size_t *nranks);
+
+typedef struct {
+    int in_progress;
+    pmix_value_t *kv;
+    int status;
+} get_cbdata;
+
+#define SET_KEY(key, fence_num, ind, use_same_keys) do {                                                            \
+    if (use_same_keys) {                                                                                            \
+        (void)snprintf(key, sizeof(key)-1, "key-%d", ind);                                                            \
+    } else {                                                                                                        \
+        (void)snprintf(key, sizeof(key)-1, "key-f%d:%d", fence_num, ind);                                             \
+    }                                                                                                               \
+} while (0)
+
+#define PUT(dtype, data, flag, fence_num, ind, use_same_keys) do {                                                  \
+    char key[50];                                                                                                   \
+    pmix_value_t value;                                                                                             \
+    SET_KEY(key, fence_num, ind, use_same_keys);                                                                    \
+    PMIX_VAL_SET(&value, dtype, data);                                                                              \
+    TEST_VERBOSE(("%s:%d put key %s", my_nspace, my_rank, key));                                                  \
+    if (PMIX_SUCCESS != (rc = PMIx_Put(flag, key, &value))) {                                                       \
+        TEST_ERROR(("%s:%d: PMIx_Put key %s failed: %d", my_nspace, my_rank, key, rc));                             \
+        rc = PMIX_ERROR;                                                                                            \
+    }                                                                                                               \
+    PMIX_VALUE_DESTRUCT(&value);                                                                                    \
+} while (0)
+
+#define GET(dtype, data, ns, r, fence_num, ind, use_same_keys, blocking, ok_notfnd) do {                        \
+    char key[50];                                                                                                   \
+    pmix_value_t *val;                                                                                              \
+    get_cbdata cbdata;                                                                                              \
+    cbdata.status = PMIX_SUCCESS;                                                                                   \
+    pmix_proc_t foobar; \
+    SET_KEY(key, fence_num, ind, use_same_keys);                                                                    \
+    (void)strncpy(foobar.nspace, ns, PMIX_MAX_NSLEN); \
+    foobar.rank = r; \
+    TEST_VERBOSE(("%s:%d want to get from %s:%d key %s", my_nspace, my_rank, ns, r, key));                          \
+    if (blocking) {                                                                                                 \
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&foobar, key, NULL, 0, &val))) {                                         \
+            if( !( rc == PMIX_ERR_NOT_FOUND && ok_notfnd ) ){                                                       \
+                TEST_ERROR(("%s:%d: PMIx_Get failed: %d from %s:%d, key %s", my_nspace, my_rank, rc, ns, r, key));  \
+            }                                                                                                       \
+            rc = PMIX_ERROR;                                                                                        \
+        }                                                                                                           \
+    } else {                                                                                                        \
+        int count;                                                                                                  \
+        cbdata.in_progress = 1;                                                                                     \
+        PMIX_VALUE_CREATE(val, 1);                                                                                  \
+        cbdata.kv = val;                                                                                            \
+        if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&foobar, key, NULL, 0, get_cb, (void*)&cbdata))) {                    \
+            TEST_VERBOSE(("%s:%d: PMIx_Get_nb failed: %d from %s:%d, key=%s", my_nspace, my_rank, rc, ns, r, key)); \
+            rc = PMIX_ERROR;                                                                                        \
+        } else {                                                                                                    \
+            count = 0;                                                                                              \
+            while(cbdata.in_progress){                                                                              \
+                struct timespec ts;                                                                                 \
+                ts.tv_sec = 0;                                                                                      \
+                ts.tv_nsec = 100;                                                                                   \
+                nanosleep(&ts,NULL);                                                                                \
+                count++;                                                                                            \
+            }                                                                                                       \
+        }                                                                                                           \
+    }                                                                                                               \
+    if (PMIX_SUCCESS == rc) {                                                                                       \
+        if( PMIX_SUCCESS != cbdata.status ){                                                                        \
+            if( !( rc == PMIX_ERR_NOT_FOUND && ok_notfnd ) ){                                                       \
+                TEST_VERBOSE(("%s:%d: PMIx_Get_nb failed: %d from %s:%d, key=%s",                                   \
+                            my_nspace, my_rank, rc, my_nspace, r));                                                 \
+            }                                                                                                       \
+            rc = PMIX_ERROR;                                                                                        \
+        } else if (NULL == val) {                                                                                   \
+            TEST_VERBOSE(("%s:%d: PMIx_Get returned NULL value", my_nspace, my_rank));                              \
+            rc = PMIX_ERROR;                                                                                        \
+        }                                                                                                           \
+        else if (val->type != PMIX_VAL_TYPE_ ## dtype || PMIX_VAL_CMP(dtype, PMIX_VAL_FIELD_ ## dtype((val)), data)) {  \
+            TEST_VERBOSE(("%s:%u: from %s:%d Key %s value or type mismatch,"                                        \
+                        " want type %d get type %d",                                                                \
+                        my_nspace, my_rank, ns, r, key, PMIX_VAL_TYPE_ ## dtype, val->type));                    \
+            rc = PMIX_ERROR;                                                                                        \
+        }                                                                                                           \
+    }                                                                                                               \
+    if (PMIX_SUCCESS == rc) {                                                                                       \
+        TEST_VERBOSE(("%s:%d: GET OF %s from %s:%d SUCCEEDED", my_nspace, my_rank, key, ns, r));                 \
+        PMIX_VALUE_RELEASE(val);                                                                                    \
+    }                                                                                                               \
+} while (0)
+
+#define FENCE(blocking, data_ex, pcs, nprocs) do {                              \
+    if( blocking ){                                                             \
+        pmix_info_t *info = NULL;                                               \
+        size_t ninfo = 0;                                                       \
+        if (data_ex) {                                                          \
+            bool value = 1;                                            \
+            PMIX_INFO_CREATE(info, 1);                                          \
+            (void)strncpy(info->key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);       \
+            pmix_value_load(&info->value, &value, PMIX_BOOL);                   \
+            ninfo = 1;                                                          \
+        }                                                                       \
+        rc = PMIx_Fence(pcs, nprocs, info, ninfo);                              \
+        PMIX_INFO_FREE(info, ninfo);                                            \
+    } else {                                                                    \
+        int in_progress = 1, count;                                             \
+        rc = PMIx_Fence_nb(pcs, nprocs, NULL, 0, release_cb, &in_progress);     \
+        if ( PMIX_SUCCESS == rc ) {                                             \
+            count = 0;                                                          \
+            while( in_progress ){                                               \
+                struct timespec ts;                                             \
+                ts.tv_sec = 0;                                                  \
+                ts.tv_nsec = 100;                                               \
+                nanosleep(&ts,NULL);                                            \
+                count++;                                                        \
+            }                                                                   \
+            TEST_VERBOSE(("PMIx_Fence_nb(barrier,collect): free time: %lfs",    \
+                            count*100*1E-9));                                   \
+        }                                                                       \
+    }                                                                           \
+    if (PMIX_SUCCESS == rc) {                                                   \
+        TEST_VERBOSE(("%s:%d: Fence successfully completed",                    \
+                        my_nspace, my_rank));                                   \
+    }                                                                           \
+} while (0)
 
 #endif // TEST_COMMON_H

--- a/test/test_fence.c
+++ b/test/test_fence.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016      Intel, Inc.  All rights reserved.
- * Copyright (c) 2015      Mellanox Technologies, Inc.
+ * Copyright (c) 2015-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
  *
@@ -12,18 +12,6 @@
 
 #include "test_fence.h"
 #include "src/buffer_ops/buffer_ops.h"
-
-static void release_cb(pmix_status_t status, void *cbdata)
-{
-    int *ptr = (int*)cbdata;
-    *ptr = 0;
-}
-
-typedef struct {
-    int in_progress;
-    pmix_value_t *kv;
-    int status;
-} get_cbdata;
 
 static void get_cb(pmix_status_t status, pmix_value_t *kv, void *cbdata)
 {
@@ -58,121 +46,11 @@ static void add_noise(char *noise_param, char *my_nspace, pmix_rank_t my_rank)
     }
 }
 
-#define SET_KEY(key, fence_num, ind, use_same_keys) do {                                                            \
-    if (use_same_keys) {                                                                                            \
-        (void)snprintf(key, sizeof(key)-1, "key-%d", ind);                                                            \
-    } else {                                                                                                        \
-        (void)snprintf(key, sizeof(key)-1, "key-f%d:%d", fence_num, ind);                                             \
-    }                                                                                                               \
-} while (0)
-
-#define PUT(dtype, data, flag, fence_num, ind, use_same_keys) do {                                                  \
-    char key[50];                                                                                                   \
-    pmix_value_t value;                                                                                             \
-    SET_KEY(key, fence_num, ind, use_same_keys);                                                                    \
-    PMIX_VAL_SET(&value, dtype, data);                                                                              \
-    TEST_VERBOSE(("%s:%d put key %s", my_nspace, my_rank, key));                                                  \
-    if (PMIX_SUCCESS != (rc = PMIx_Put(flag, key, &value))) {                                                       \
-        TEST_ERROR(("%s:%d: PMIx_Put key %s failed: %d", my_nspace, my_rank, key, rc));                             \
-        rc = PMIX_ERROR;                                                                                            \
-    }                                                                                                               \
-    PMIX_VALUE_DESTRUCT(&value);                                                                                    \
-} while (0)
-
-#define GET(dtype, data, ns, r, fence_num, ind, use_same_keys, blocking, ok_notfnd) do {                        \
-    char key[50];                                                                                                   \
-    pmix_value_t *val;                                                                                              \
-    get_cbdata cbdata;                                                                                              \
-    cbdata.status = PMIX_SUCCESS;                                                                                   \
-    pmix_proc_t foobar; \
-    SET_KEY(key, fence_num, ind, use_same_keys);                                                                    \
-    (void)strncpy(foobar.nspace, ns, PMIX_MAX_NSLEN); \
-    foobar.rank = r; \
-    TEST_VERBOSE(("%s:%d want to get from %s:%d key %s", my_nspace, my_rank, ns, r, key));                          \
-    if (blocking) {                                                                                                 \
-        if (PMIX_SUCCESS != (rc = PMIx_Get(&foobar, key, NULL, 0, &val))) {                                         \
-            if( !( rc == PMIX_ERR_NOT_FOUND && ok_notfnd ) ){                                                       \
-                TEST_ERROR(("%s:%d: PMIx_Get failed: %d from %s:%d, key %s", my_nspace, my_rank, rc, ns, r, key));  \
-            }                                                                                                       \
-            rc = PMIX_ERROR;                                                                                        \
-        }                                                                                                           \
-    } else {                                                                                                        \
-        int count;                                                                                                  \
-        cbdata.in_progress = 1;                                                                                     \
-        PMIX_VALUE_CREATE(val, 1);                                                                                  \
-        cbdata.kv = val;                                                                                            \
-        if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&foobar, key, NULL, 0, get_cb, (void*)&cbdata))) {                    \
-            TEST_VERBOSE(("%s:%d: PMIx_Get_nb failed: %d from %s:%d, key=%s", my_nspace, my_rank, rc, ns, r, key)); \
-            rc = PMIX_ERROR;                                                                                        \
-        } else {                                                                                                    \
-            count = 0;                                                                                              \
-            while(cbdata.in_progress){                                                                              \
-                struct timespec ts;                                                                                 \
-                ts.tv_sec = 0;                                                                                      \
-                ts.tv_nsec = 100;                                                                                   \
-                nanosleep(&ts,NULL);                                                                                \
-                count++;                                                                                            \
-            }                                                                                                       \
-        }                                                                                                           \
-    }                                                                                                               \
-    if (PMIX_SUCCESS == rc) {                                                                                       \
-        if( PMIX_SUCCESS != cbdata.status ){                                                                        \
-            if( !( rc == PMIX_ERR_NOT_FOUND && ok_notfnd ) ){                                                       \
-                TEST_VERBOSE(("%s:%d: PMIx_Get_nb failed: %d from %s:%d, key=%s",                                   \
-                            my_nspace, my_rank, rc, my_nspace, r));                                                 \
-            }                                                                                                       \
-            rc = PMIX_ERROR;                                                                                        \
-        } else if (NULL == val) {                                                                                   \
-            TEST_VERBOSE(("%s:%d: PMIx_Get returned NULL value", my_nspace, my_rank));                              \
-            rc = PMIX_ERROR;                                                                                        \
-        }                                                                                                           \
-        else if (val->type != PMIX_VAL_TYPE_ ## dtype || PMIX_VAL_CMP(dtype, PMIX_VAL_FIELD_ ## dtype((val)), data)) {  \
-            TEST_VERBOSE(("%s:%u: from %s:%d Key %s value or type mismatch,"                                        \
-                        " want type %d get type %d",                                                                \
-                        my_nspace, my_rank, ns, r, key, PMIX_VAL_TYPE_ ## dtype, val->type));                    \
-            rc = PMIX_ERROR;                                                                                        \
-        }                                                                                                           \
-    }                                                                                                               \
-    if (PMIX_SUCCESS == rc) {                                                                                       \
-        TEST_VERBOSE(("%s:%d: GET OF %s from %s:%d SUCCEEDED", my_nspace, my_rank, key, ns, r));                 \
-        PMIX_VALUE_RELEASE(val);                                                                                    \
-    }                                                                                                               \
-} while (0)
-
-#define FENCE(blocking, data_ex, pcs, nprocs) do {                              \
-    if( blocking ){                                                             \
-        pmix_info_t *info = NULL;                                               \
-        size_t ninfo = 0;                                                       \
-        if (data_ex) {                                                          \
-            bool value = 1;                                            \
-            PMIX_INFO_CREATE(info, 1);                                          \
-            (void)strncpy(info->key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);       \
-            pmix_value_load(&info->value, &value, PMIX_BOOL);                   \
-            ninfo = 1;                                                          \
-        }                                                                       \
-        rc = PMIx_Fence(pcs, nprocs, info, ninfo);                              \
-        PMIX_INFO_FREE(info, ninfo);                                            \
-    } else {                                                                    \
-        int in_progress = 1, count;                                             \
-        rc = PMIx_Fence_nb(pcs, nprocs, NULL, 0, release_cb, &in_progress);     \
-        if ( PMIX_SUCCESS == rc ) {                                             \
-            count = 0;                                                          \
-            while( in_progress ){                                               \
-                struct timespec ts;                                             \
-                ts.tv_sec = 0;                                                  \
-                ts.tv_nsec = 100;                                               \
-                nanosleep(&ts,NULL);                                            \
-                count++;                                                        \
-            }                                                                   \
-            TEST_VERBOSE(("PMIx_Fence_nb(barrier,collect): free time: %lfs",    \
-                            count*100*1E-9));                                   \
-        }                                                                       \
-    }                                                                           \
-    if (PMIX_SUCCESS == rc) {                                                   \
-        TEST_VERBOSE(("%s:%d: Fence successfully completed",                    \
-                        my_nspace, my_rank));                                   \
-    }                                                                           \
-} while (0)
+static void release_cb(pmix_status_t status, void *cbdata)
+{
+    int *ptr = (int*)cbdata;
+    *ptr = 0;
+}
 
 int test_fence(test_params params, char *my_nspace, pmix_rank_t my_rank)
 {
@@ -193,6 +71,8 @@ int test_fence(test_params params, char *my_nspace, pmix_rank_t my_rank)
 
     PMIX_CONSTRUCT(&test_fences, pmix_list_t);
     parse_fence(params.fences, 1);
+
+    TEST_VERBOSE(("fences %s\n", params.fences));
 
     /* cycle thru all the test fence descriptors to find
      * those that include my nspace/rank */

--- a/test/test_internal.c
+++ b/test/test_internal.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2017      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "test_internal.h"
+
+static void release_cb(pmix_status_t status, void *cbdata)
+{
+    int *ptr = (int*)cbdata;
+    *ptr = 0;
+}
+
+static void get_cb(pmix_status_t status, pmix_value_t *kv, void *cbdata)
+{
+    get_cbdata *cb = (get_cbdata*)cbdata;
+    if (PMIX_SUCCESS == status) {
+        pmix_value_xfer(cb->kv, kv);
+    }
+    cb->in_progress = 0;
+    cb->status = status;
+}
+
+int test_internal(char *my_nspace, pmix_rank_t my_rank, test_params params) {
+    int idx;
+    char sval[PMIX_MAX_NSLEN];
+    char key[PMIX_MAX_KEYLEN];
+    pmix_value_t value;
+    pmix_proc_t proc;
+    pmix_status_t rc;
+
+    PMIX_PROC_CONSTRUCT(&proc);
+    (void)strncpy(proc.nspace, my_nspace, PMIX_MAX_NSLEN);
+    proc.rank = my_rank;
+
+    for (idx = 0; idx < params.test_internal; idx++) {
+        memset(sval, 0, PMIX_MAX_NSLEN);
+        sprintf(sval, "test_internal:%s:%d:%d", my_nspace, my_rank, idx);
+
+        SET_KEY(key, 0, idx, 1);
+        value.type = PMIX_STRING;
+        value.data.string = sval;
+        if (PMIX_SUCCESS != (rc = PMIx_Store_internal(&proc, key, &value))) {
+            TEST_ERROR(("%s:%d: PMIx_Store_internal failed: %d", my_nspace, my_rank, rc));
+            PMIX_PROC_DESTRUCT(&proc);
+            return PMIX_ERROR;
+        }
+    }
+
+    /* Submit the data */
+    if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
+        TEST_ERROR(("%s:%d: PMIx_Commit failed: %d", my_nspace, my_rank, rc));
+        PMIX_LIST_DESTRUCT(&key_replace);
+        PMIX_PROC_DESTRUCT(&proc);
+        return PMIX_ERROR;
+    }
+
+    proc.rank = PMIX_RANK_WILDCARD;
+    FENCE(1, 1, (&proc), 1);
+    if (PMIX_SUCCESS != rc) {
+        TEST_ERROR(("%s:%d: PMIx_Fence failed: %d", my_nspace, my_rank, rc));
+        PMIX_LIST_DESTRUCT(&key_replace);
+        PMIX_PROC_DESTRUCT(&proc);
+        return rc;
+    }
+
+    for (idx = 0; idx < params.test_internal; idx++) {
+        memset(sval, 0, PMIX_MAX_NSLEN);
+        sprintf(sval, "test_internal:%s:%d:%d", my_nspace, my_rank, idx);
+
+        GET(string, sval, my_nspace, my_rank, 0, idx, 1, 1, 0);
+        if (PMIX_SUCCESS != rc) {
+            TEST_ERROR(("%s:%d: PMIx_Get of remote key on local proc", my_nspace, my_rank));
+            PMIX_PROC_DESTRUCT(&proc);
+            return PMIX_ERROR;
+        }
+    }
+
+    PMIX_PROC_DESTRUCT(&proc);
+    return PMIX_SUCCESS;
+}

--- a/test/test_internal.h
+++ b/test/test_internal.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2017      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include <src/include/pmix_config.h>
+#include <pmix.h>
+
+#include "test_common.h"
+
+int test_internal(char *my_nspace, pmix_rank_t my_rank, test_params params);

--- a/test/test_replace.c
+++ b/test/test_replace.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2017      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "test_replace.h"
+
+static void release_cb(pmix_status_t status, void *cbdata)
+{
+    int *ptr = (int*)cbdata;
+    *ptr = 0;
+}
+
+static void get_cb(pmix_status_t status, pmix_value_t *kv, void *cbdata)
+{
+    get_cbdata *cb = (get_cbdata*)cbdata;
+    if (PMIX_SUCCESS == status) {
+        pmix_value_xfer(cb->kv, kv);
+    }
+    cb->in_progress = 0;
+    cb->status = status;
+}
+
+static int key_is_replace(int key_idx) {
+    key_replace_t *item;
+
+    PMIX_LIST_FOREACH(item, &key_replace, key_replace_t) {
+        if (item->key_idx == key_idx)
+            return 1;
+    }
+    return 0;
+}
+
+int test_replace(char *my_nspace, pmix_rank_t my_rank, test_params params) {
+    int key_idx = 0;
+    int key_cnt = 0;
+    char sval[PMIX_MAX_NSLEN];
+    pmix_proc_t proc;
+    pmix_status_t rc;
+    key_replace_t *item;
+
+    PMIX_CONSTRUCT(&key_replace, pmix_list_t);
+    parse_replace(params.key_replace, 1, &key_cnt);
+
+    for (key_idx = 0; key_idx < key_cnt; key_idx++) {
+        memset(sval, 0, PMIX_MAX_NSLEN);
+        sprintf(sval, "test_replace:%s:%d:%d", my_nspace, my_rank, key_idx);
+
+        PUT(string, sval, PMIX_GLOBAL, 0, key_idx, 1);
+        if (PMIX_SUCCESS != rc) {
+            TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
+            PMIX_LIST_DESTRUCT(&key_replace);
+            return rc;
+        }
+    }
+
+    PMIX_PROC_CONSTRUCT(&proc);
+    (void)strncpy(proc.nspace, my_nspace, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_WILDCARD;
+
+    /* Submit the data */
+    if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
+        TEST_ERROR(("%s:%d: PMIx_Commit failed: %d", my_nspace, my_rank, rc));
+        PMIX_LIST_DESTRUCT(&key_replace);
+        PMIX_PROC_DESTRUCT(&proc);
+        return PMIX_ERROR;
+    }
+
+    FENCE(1, 1, (&proc), 1);
+    if (PMIX_SUCCESS != rc) {
+        TEST_ERROR(("%s:%d: PMIx_Fence failed: %d", my_nspace, my_rank, rc));
+        PMIX_LIST_DESTRUCT(&key_replace);
+        PMIX_PROC_DESTRUCT(&proc);
+        return rc;
+    }
+
+    PMIX_LIST_FOREACH(item, &key_replace, key_replace_t) {
+        memset(sval, 0, PMIX_MAX_NSLEN);
+        sprintf(sval, "test_replace:%s:%d:%d: replaced key", my_nspace, my_rank, item->key_idx);
+
+        PUT(string, sval, PMIX_GLOBAL, 0, item->key_idx, 1);
+        if (PMIX_SUCCESS != rc) {
+            TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
+            PMIX_LIST_DESTRUCT(&key_replace);
+            PMIX_PROC_DESTRUCT(&proc);
+            return rc;
+        }
+    }
+
+
+    /* Submit the data */
+    if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
+        TEST_ERROR(("%s:%d: PMIx_Commit failed: %d", my_nspace, my_rank, rc));
+        PMIX_LIST_DESTRUCT(&key_replace);
+        PMIX_PROC_DESTRUCT(&proc);
+        return PMIX_ERROR;
+    }
+
+    FENCE(1, 1, (&proc), 1);
+    if (PMIX_SUCCESS != rc) {
+        TEST_ERROR(("%s:%d: PMIx_Fence failed: %d", my_nspace, my_rank, rc));
+        PMIX_LIST_DESTRUCT(&key_replace);
+        PMIX_PROC_DESTRUCT(&proc);
+        return rc;
+    }
+
+    for (key_idx = 0; key_idx < key_cnt; key_idx++) {
+        memset(sval, 0, PMIX_MAX_NSLEN);
+
+        if (key_is_replace(key_idx)) {
+            sprintf(sval, "test_replace:%s:%d:%d: replaced key", my_nspace, my_rank, key_idx);
+        } else {
+            sprintf(sval, "test_replace:%s:%d:%d", my_nspace, my_rank, key_idx);
+        }
+
+
+        GET(string, sval, my_nspace, my_rank, 0, key_idx, 1, 1, 0);
+        if (PMIX_SUCCESS != rc) {
+            TEST_ERROR(("%s:%d: PMIx_Get of remote key on local proc", my_nspace, my_rank));
+            PMIX_LIST_DESTRUCT(&key_replace);
+            PMIX_PROC_DESTRUCT(&proc);
+            return PMIX_ERROR;
+        }
+    }
+
+    PMIX_LIST_DESTRUCT(&key_replace);
+    PMIX_PROC_DESTRUCT(&proc);
+    return PMIX_SUCCESS;
+}

--- a/test/test_replace.h
+++ b/test/test_replace.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2017      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include <src/include/pmix_config.h>
+#include <pmix.h>
+
+#include "test_common.h"
+
+int test_replace(char *my_nspace, pmix_rank_t my_rank, test_params params);

--- a/test/utils.c
+++ b/test/utils.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015      Intel, Inc.  All rights reserved.
- * Copyright (c) 2015      Mellanox Technologies, Inc.
+ * Copyright (c) 2015-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -154,6 +154,16 @@ void set_client_argv(test_params *params, char ***argv)
     }
     if (params->test_error) {
         pmix_argv_append_nosize(argv, "--test-error");
+    }
+    if (params->key_replace) {
+        pmix_argv_append_nosize(argv, "--test-replace");
+        pmix_argv_append_nosize(argv, params->key_replace);
+    }
+    if (params->test_internal) {
+        char tmp[32];
+        sprintf(tmp, "%d", params->test_internal);
+        pmix_argv_append_nosize(argv, "--test-internal");
+        pmix_argv_append_nosize(argv, tmp);
     }
 }
 


### PR DESCRIPTION
- Add the key replacement test.
  The option to activate test of replacement: `./pmix_test --test-replace`

- Add the key internal store test: `./pmix_test --test-internal`