### PR TITLE
Adjust default buffer size for performance

### DIFF
--- a/src/buffer_ops/internal.h
+++ b/src/buffer_ops/internal.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -45,12 +45,12 @@
 /*
  * The default starting chunk size
  */
-#define PMIX_BFROP_DEFAULT_INITIAL_SIZE  128
+#define PMIX_BFROP_DEFAULT_INITIAL_SIZE  2048
 /*
  * The default threshold size when we switch from doubling the
  * buffer size to addatively increasing it
  */
-#define PMIX_BFROP_DEFAULT_THRESHOLD_SIZE 1024
+#define PMIX_BFROP_DEFAULT_THRESHOLD_SIZE 4096
 
 /*
  * Internal type corresponding to size_t.  Do not use this in

--- a/src/buffer_ops/open_close.c
+++ b/src/buffer_ops/open_close.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -174,7 +174,7 @@ pmix_status_t pmix_bfrop_open(void)
     }
     pmix_bfrop_num_reg_types = PMIX_UNDEF;
     pmix_bfrop_threshold_size = PMIX_BFROP_DEFAULT_THRESHOLD_SIZE;
-    pmix_bfrop_initial_size = 1;
+    pmix_bfrop_initial_size = PMIX_BFROP_DEFAULT_INITIAL_SIZE;
 
     /* Register all the supported types */
     PMIX_REGISTER_TYPE("PMIX_BOOL", PMIX_BOOL,


### PR DESCRIPTION
Set the default buffer size using the defined constant, and up that size to 2kBytes. This reduces the number of realloc's as we pack things and saves considerable time

Signed-off-by: Ralph Castain <rhc@open-mpi.org>