### PR TITLE
dstore: Fix significant performance degradation.

### DIFF
--- a/src/common/pmix_jobdata.c
+++ b/src/common/pmix_jobdata.c
@@ -372,12 +372,9 @@ static inline pmix_status_t _job_data_store(const char *nspace, void *cbdata)
 
 #if defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1)
     if (NULL != cb->dstore_fn) {
-        uint32_t size = (uint32_t)pmix_value_array_get_size(cb->bufs);
-        for (i = 0; i < size; i++) {
-            if (PMIX_SUCCESS != (rc = _rank_key_dstore_store(cbdata))) {
-                PMIX_ERROR_LOG(rc);
-                goto exit;
-            }
+        if (PMIX_SUCCESS != (rc = _rank_key_dstore_store(cbdata))) {
+            PMIX_ERROR_LOG(rc);
+            goto exit;
         }
     }
 #endif


### PR DESCRIPTION
Accidentally loop that was submitting jobinfo data was duplicated
in two nested functions. As the result computational complexity
rised from O(n) to O(n^2) which caused significant performance
hit at 8k node level (thanks to @hjelmn for noticing and doing
initial analysis!)
This bug wasn't visible at dstore data level because if for the key
being replaced the size of the data was the same - key was simply
rewritten.