### PR TITLE
sm: use posix_fallocate() before mmap'ing it

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -18,7 +18,7 @@ dnl                         reserved.
 dnl Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2011-2013 NVIDIA Corporation.  All rights reserved.
 dnl Copyright (c) 2013-2016 Intel, Inc. All rights reserved
-dnl Copyright (c) 2015      Research Organization for Information Science
+dnl Copyright (c) 2015-2017 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      Mellanox Technologies, Inc.
 dnl                         All rights reserved.
@@ -500,7 +500,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     # Darwin doesn't need -lm, as it's a symlink to libSystem.dylib
     PMIX_SEARCH_LIBS_CORE([ceil], [m])
 
-    AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf strsignal socketpair strncpy_s usleep statfs statvfs getpeereid getpeerucred strnlen])
+    AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf strsignal socketpair strncpy_s usleep statfs statvfs getpeereid getpeerucred strnlen posix_fallocate])
 
     # On some hosts, htonl is a define, so the AC_CHECK_FUNC will get
     # confused.  On others, it's in the standard library, but stubbed with

--- a/src/sm/pmix_mmap.c
+++ b/src/sm/pmix_mmap.c
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2015-2016 Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -16,6 +18,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <errno.h>
 
 #include <pmix/pmix_common.h>
 #include "src/include/pmix_globals.h"
@@ -58,12 +61,25 @@ int _mmap_segment_create(pmix_sm_seg_t *sm_seg, const char *file_name, size_t si
         goto out;
     }
     /* size backing file - note the use of real_size here */
+#ifdef HAVE_POSIX_FALLOCATE
+    if (0 != posix_fallocate(sm_seg->seg_id, 0, size)) {
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                "sys call posix_fallocate(2) fail\n");
+        if (ENOSPC == errno) {
+            rc = PMIX_ERR_OUT_OF_RESOURCE;
+        } else {
+            rc = PMIX_ERROR;
+        }
+        goto out;
+    }
+#else
     if (0 != ftruncate(sm_seg->seg_id, size)) {
         pmix_output_verbose(2, pmix_globals.debug_output,
                 "sys call ftruncate(2) fail\n");
         rc = PMIX_ERROR;
         goto out;
     }
+#endif
     if (MAP_FAILED == (seg_addr = mmap(NULL, size,
                                        PROT_READ | PROT_WRITE, MAP_SHARED,
                                        sm_seg->seg_id, 0))) {


### PR DESCRIPTION
if the filesystem is full, both ftruncate() and mmap() success, but
a crash occurs when accessing the mmap'ed memory.
unlike ftruncate(), posix_fallocate() does fail when the filesystem
is full

Thanks Boris Karasev for the review

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>

(back-ported from commit pmix/master@84d2f4668f17177b17d44ee02c4b7dc7ba03d166)