### PR TITLE
dstore: Added locking by pthread.

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -35,6 +35,7 @@ EXTRA_DIST = \
 	pmix_check_package.m4 \
 	pmix_check_vendor.m4 \
 	pmix_check_visibility.m4 \
+	pmix_check_lock.m4 \
 	pmix_config_subdir.m4 \
 	pmix_ensure_contains_optflags.m4 \
 	pmix_functions.m4 \

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -655,6 +655,14 @@ AC_DEFUN([PMIX_SETUP_CORE],[
 
     PMIX_MCA
 
+    ##################################
+    # Dstore Locking
+    ##################################
+
+    pmix_show_title "Dstore Locking"
+
+    PMIX_CHECK_DSTOR_LOCK
+
     ############################################################################
     # final compiler config
     ############################################################################
@@ -867,6 +875,7 @@ AC_DEFINE_UNQUOTED([PMIX_WANT_PRETTY_PRINT_STACKTRACE],
                    [$WANT_PRETTY_PRINT_STACKTRACE],
                    [if want pretty-print stack trace feature])
 
+#
 # Do we want the shared memory datastore usage?
 #
 
@@ -886,7 +895,22 @@ AC_DEFINE_UNQUOTED([PMIX_ENABLE_DSTORE],
                  [if want shared memory dstore feature])
 
 #
+# Use pthread-based locking
+#
+DSTORE_PTHREAD_LOCK="1"
+AC_MSG_CHECKING([if want dstore pthread-based locking])
+AC_ARG_ENABLE([dstore-pthlck],
+              [AC_HELP_STRING([--disable-dstore-pthlck],
+                              [Disable pthread-based lockig in dstor (default: enabled)])])
+if test "$enable_dstore_pthlck" == "no" ; then
+    AC_MSG_RESULT([no])
+    DSTORE_PTHREAD_LOCK="0"
+else
+    AC_MSG_RESULT([yes])
+    DSTORE_PTHREAD_LOCK="1"
+fi
 
+#
 # Ident string
 #
 AC_MSG_CHECKING([if want ident string])

--- a/config/pmix_check_lock.m4
+++ b/config/pmix_check_lock.m4
@@ -1,0 +1,57 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2017      Mellanox Technologies, Inc.
+dnl                         All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+AC_DEFUN([PMIX_CHECK_DSTOR_LOCK],[
+    orig_libs=$LIBS
+    LIBS="-lpthread $LIBS"
+
+    _x_ac_pthread_lock_found="0"
+    _x_ac_fcntl_lock_found="0"
+
+    AC_CHECK_MEMBERS([struct flock.l_type],
+    [
+        AC_DEFINE([HAVE_FCNTL_FLOCK], [1],
+        [Define to 1 if you have the locking by fcntl.])
+        _x_ac_fcntl_lock_found="1"
+    ], [], [#include <fcntl.h>])
+
+    if test "$ESH_PTHREAD_LOCK" == "1"; then
+        AC_CHECK_FUNC([pthread_rwlockattr_setkind_np],
+            [AC_EGREP_HEADER([PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP],
+                    [pthread.h],[
+                        AC_DEFINE([HAVE_PTHREAD_SETKIND], [1],
+                            [Define to 1 if you have the `pthread_rwlockattr_setkind_np` function.])])])
+
+        AC_CHECK_FUNC([pthread_rwlockattr_setpshared],
+            [AC_EGREP_HEADER([PTHREAD_PROCESS_SHARED],
+                    [pthread.h],[
+                        AC_DEFINE([HAVE_PTHREAD_SHARED], [1],
+                            [Define to 1 if you have the `PTHREAD_PROCESS_SHARED` definition.
+                        ])
+                        _x_ac_pthread_lock_found="1"
+            ])
+        ])
+
+        if test "$_x_ac_pthread_lock_found" == "0"; then
+            if test "$_x_ac_fcntl_lock_found" == "1"; then
+                AC_MSG_WARN([dstore: pthread-based locking not found, will use fcntl-based locking.])
+            else
+                AC_MSG_ERROR([dstore: no available locking mechanisms was found. Can not continue. Try disabling dstore])
+            fi
+        fi
+    else
+        if test "$_x_ac_fcntl_lock_found" == "0"; then
+            AC_MSG_ERROR([dstore: no available locking mechanisms was found. Can not continue. Try disabling dstore])
+        fi
+    fi
+
+    LIBS="$orig_libs"
+])

--- a/src/dstore/pmix_esh.h
+++ b/src/dstore/pmix_esh.h
@@ -26,21 +26,12 @@ BEGIN_C_DECLS
 
 #define PMIX_DSTORE_ESH_BASE_PATH "PMIX_DSTORE_ESH_BASE_PATH"
 
-#define PTHREAD_LOCK_ENABLE 1
-#define FCNTL_LOCK_ENABLE   0
-
-#if defined(PTHREAD_LOCK_ENABLE) || defined(FCNTL_LOCK_ENABLE)
-#if (PTHREAD_LOCK_ENABLE == 1)
-#undef FCNTL_LOCK_ENABLE
-#define PTHREAD_LOCK
+#ifdef HAVE_PTHREAD_SHARED
+#define ESH_PTHREAD_LOCK
+#elif defined HAVE_FCNTL_FLOCK
+#define ESH_FCNTL_LOCK
 #else
-#undef PTHREAD_LOCK_ENABLE
-#define FCNTL_LOCK
-#endif
-#elif !(defined(PTHREAD_LOCK_ENABLE) || defined(FCNTL_LOCK_ENABLE))
-#error not enabled any one type of locking
-#else
-#define PTHREAD_LOCK
+#error No locking mechanism was found
 #endif
 
 /* this structs are used to store information about
@@ -66,14 +57,13 @@ struct seg_desc_t {
 typedef struct ns_map_data_s ns_map_data_t;
 typedef struct session_s session_t;
 typedef struct ns_map_s ns_map_t;
-typedef struct rwlock_map_s rwlock_map_t;
 
 struct session_s {
     int in_use;
     uid_t jobuid;
     char *nspace_path;
     char *lockfile;
-#ifdef PTHREAD_LOCK
+#ifdef ESH_PTHREAD_LOCK
     pmix_sm_seg_t *rwlock_seg;
     pthread_rwlock_t *rwlock;
 #endif

--- a/src/dstore/pmix_esh.h
+++ b/src/dstore/pmix_esh.h
@@ -26,6 +26,23 @@ BEGIN_C_DECLS
 
 #define PMIX_DSTORE_ESH_BASE_PATH "PMIX_DSTORE_ESH_BASE_PATH"
 
+#define PTHREAD_LOCK_ENABLE 1
+#define FCNTL_LOCK_ENABLE   0
+
+#if defined(PTHREAD_LOCK_ENABLE) || defined(FCNTL_LOCK_ENABLE)
+#if (PTHREAD_LOCK_ENABLE == 1)
+#undef FCNTL_LOCK_ENABLE
+#define PTHREAD_LOCK
+#else
+#undef PTHREAD_LOCK_ENABLE
+#define FCNTL_LOCK
+#endif
+#elif !(defined(PTHREAD_LOCK_ENABLE) || defined(FCNTL_LOCK_ENABLE))
+#error not enabled any one type of locking
+#else
+#define PTHREAD_LOCK
+#endif
+
 /* this structs are used to store information about
  * shared segments addresses locally at each process,
  * so they are common for different types of segments
@@ -49,12 +66,17 @@ struct seg_desc_t {
 typedef struct ns_map_data_s ns_map_data_t;
 typedef struct session_s session_t;
 typedef struct ns_map_s ns_map_t;
+typedef struct rwlock_map_s rwlock_map_t;
 
 struct session_s {
     int in_use;
     uid_t jobuid;
     char *nspace_path;
     char *lockfile;
+#ifdef PTHREAD_LOCK
+    pmix_sm_seg_t *rwlock_seg;
+    pthread_rwlock_t *rwlock;
+#endif
     int lockfd;
     seg_desc_t *sm_seg_first;
     seg_desc_t *sm_seg_last;


### PR DESCRIPTION
Added alternative locking by `pthread` with use shared memory region
for the lock. The code path of old locking by `flock` has been saved
for evaluate performance against locking by `pthread` and other purposes.

To change the locking type needs to enable the code paths by macro:
```C  
#define PTHREAD_LOCK_ENABLE  1
#define FCNTL_LOCK_ENABLE    1
```
In priority uses the locking by `pthread`

Thanks to @artpol84 for this proof of concept.
- The  results of locking by `pthread` here: https://github.com/pmix/master/pull/260#issuecomment-273945190
- Code base of concept: https://github.com/artpol84/poc/tree/master/benchmarks/shmem_locking


Signed-off-by: Boris Karasev <karasev.b@gmail.com>