### PR TITLE
dstore: Added locking by pthread.

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -40,6 +40,7 @@ EXTRA_DIST += \
 	config/pmix_check_sasl.m4 \
 	config/pmix_check_vendor.m4 \
 	config/pmix_check_visibility.m4 \
+	config/pmix_check_lock.m4 \
 	config/pmix_ensure_contains_optflags.m4 \
 	config/pmix_functions.m4 \
 	config/pmix.m4 \
@@ -47,7 +48,6 @@ EXTRA_DIST += \
 	config/pmix_setup_cc.m4 \
 	config/pmix_setup_hwloc.m4 \
 	config/pmix_setup_libevent.m4
-
 
 maintainer-clean-local:
 	rm -f config/pmix_get_version.sh

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -594,6 +594,14 @@ AC_DEFUN([PMIX_SETUP_CORE],[
 
     PMIX_MUNGE_CONFIG
 
+    ##################################
+    # Dstore Locking
+    ##################################
+
+    pmix_show_title "Dstore Locking"
+
+    PMIX_CHECK_DSTOR_LOCK
+
     ############################################################################
     # final compiler config
     ############################################################################
@@ -777,6 +785,22 @@ AC_DEFINE_UNQUOTED([PMIX_ENABLE_DSTORE],
                    [$WANT_DSTORE],
                    [if want shared memory dstore feature])
 AM_CONDITIONAL([WANT_DSTORE],[test "x$enable_dstore" != "xno"])
+
+#
+# Use pthread-based locking
+#
+DSTORE_PTHREAD_LOCK="1"
+AC_MSG_CHECKING([if want dstore pthread-based locking])
+AC_ARG_ENABLE([dstore-pthlck],
+              [AC_HELP_STRING([--disable-dstore-pthlck],
+                              [Disable pthread-based lockig in dstor (default: enabled)])])
+if test "$enable_dstore_pthlck" == "no" ; then
+    AC_MSG_RESULT([no])
+    DSTORE_PTHREAD_LOCK="0"
+else
+    AC_MSG_RESULT([yes])
+    DSTORE_PTHREAD_LOCK="1"
+fi
 
 #
 # Ident string

--- a/config/pmix_check_lock.m4
+++ b/config/pmix_check_lock.m4
@@ -1,0 +1,57 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2017      Mellanox Technologies, Inc.
+dnl                         All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+AC_DEFUN([PMIX_CHECK_DSTOR_LOCK],[
+    orig_libs=$LIBS
+    LIBS="-lpthread $LIBS"
+
+    _x_ac_pthread_lock_found="0"
+    _x_ac_fcntl_lock_found="0"
+
+    AC_CHECK_MEMBERS([struct flock.l_type],
+    [
+        AC_DEFINE([HAVE_FCNTL_FLOCK], [1],
+        [Define to 1 if you have the locking by fcntl.])
+        _x_ac_fcntl_lock_found="1"
+    ], [], [#include <fcntl.h>])
+
+    if test "$ESH_PTHREAD_LOCK" == "1"; then
+        AC_CHECK_FUNC([pthread_rwlockattr_setkind_np],
+            [AC_EGREP_HEADER([PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP],
+                    [pthread.h],[
+                        AC_DEFINE([HAVE_PTHREAD_SETKIND], [1],
+                            [Define to 1 if you have the `pthread_rwlockattr_setkind_np` function.])])])
+
+        AC_CHECK_FUNC([pthread_rwlockattr_setpshared],
+            [AC_EGREP_HEADER([PTHREAD_PROCESS_SHARED],
+                    [pthread.h],[
+                        AC_DEFINE([HAVE_PTHREAD_SHARED], [1],
+                            [Define to 1 if you have the `PTHREAD_PROCESS_SHARED` definition.
+                        ])
+                        _x_ac_pthread_lock_found="1"
+            ])
+        ])
+
+        if test "$_x_ac_pthread_lock_found" == "0"; then
+            if test "$_x_ac_fcntl_lock_found" == "1"; then
+                AC_MSG_WARN([dstore: pthread-based locking not found, will use fcntl-based locking.])
+            else
+                AC_MSG_ERROR([dstore: no available locking mechanisms was found. Can not continue. Try disabling dstore])
+            fi
+        fi
+    else
+        if test "$_x_ac_fcntl_lock_found" == "0"; then
+            AC_MSG_ERROR([dstore: no available locking mechanisms was found. Can not continue. Try disabling dstore])
+        fi
+    fi
+
+    LIBS="$orig_libs"
+])

--- a/src/dstore/pmix_esh.c
+++ b/src/dstore/pmix_esh.c
@@ -34,11 +34,11 @@
 #include "pmix_dstore.h"
 #include "pmix_esh.h"
 
-#ifdef FCNTL_LOCK
+#ifdef ESH_FCNTL_LOCK
 #include <fcntl.h>
 #endif
 
-#ifdef PTHREAD_LOCK
+#ifdef ESH_PTHREAD_LOCK
 #include <pthread.h>
 #endif
 
@@ -126,7 +126,7 @@ __extension__ ({                                            \
             buffer, size);                                  \
 })
 
-#ifdef PTHREAD_LOCK
+#ifdef ESH_PTHREAD_LOCK
 #define _ESH_LOCK(rwlock, operation)                        \
 __extension__ ({                                            \
     pmix_status_t ret = PMIX_SUCCESS;                       \
@@ -162,7 +162,7 @@ __extension__ ({                                            \
 })
 #endif
 
-#ifdef FCNTL_LOCK
+#ifdef ESH_FCNTL_LOCK
 #define _ESH_LOCK(lockfd, operation)                        \
 __extension__ ({                                            \
     pmix_status_t ret = PMIX_SUCCESS;                       \
@@ -260,13 +260,13 @@ ns_map_data_t * (*_esh_session_map_search)(const char *nspace) = NULL;
 #define _ESH_SESSION_sm_seg_last(tbl_idx)  (PMIX_VALUE_ARRAY_GET_BASE(_session_array, session_t)[tbl_idx].sm_seg_last)
 #define _ESH_SESSION_ns_info(tbl_idx)      (PMIX_VALUE_ARRAY_GET_BASE(_session_array, session_t)[tbl_idx].ns_info)
 
-#ifdef PTHREAD_LOCK
+#ifdef ESH_PTHREAD_LOCK
 #define _ESH_SESSION_pthread_rwlock(tbl_idx) (PMIX_VALUE_ARRAY_GET_BASE(_session_array, session_t)[tbl_idx].rwlock)
 #define _ESH_SESSION_pthread_seg(tbl_idx)   (PMIX_VALUE_ARRAY_GET_BASE(_session_array, session_t)[tbl_idx].rwlock_seg)
 #define _ESH_SESSION_lock(tbl_idx)         _ESH_SESSION_pthread_rwlock(tbl_idx)
 #endif
 
-#ifdef FCNTL_LOCK
+#ifdef ESH_FCNTL_LOCK
 #define _ESH_SESSION_lockfd(tbl_idx)       (PMIX_VALUE_ARRAY_GET_BASE(_session_array, session_t)[tbl_idx].lockfd)
 #define _ESH_SESSION_lock(tbl_idx)         _ESH_SESSION_lockfd(tbl_idx)
 #endif
@@ -308,7 +308,7 @@ static inline void _esh_session_map_clean(ns_map_t *m) {
     m->data.track_idx = -1;
 }
 
-#ifdef PTHREAD_LOCK
+#ifdef ESH_PTHREAD_LOCK
 static inline int _rwlock_init(size_t idx, char *lockfile) {
     pmix_status_t rc = PMIX_SUCCESS;
     size_t size = _lock_segment_size;
@@ -342,6 +342,14 @@ static inline int _rwlock_init(size_t idx, char *lockfile) {
             pthread_rwlockattr_destroy(&attr);
             return rc;
         }
+#ifdef HAVE_PTHREAD_SETKIND
+        if (0 != pthread_rwlockattr_setkind_np(&attr, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP)) {
+            rc = PMIX_ERR_INIT;
+            pmix_sm_segment_detach(_ESH_SESSION_pthread_seg(idx));
+            pthread_rwlockattr_destroy(&attr);
+            return rc;
+        }
+#endif
         if (0 != pthread_rwlock_init(_ESH_SESSION_pthread_rwlock(idx), &attr)) {
             rc = PMIX_ERR_INIT;
             pmix_sm_segment_detach(_ESH_SESSION_pthread_seg(idx));
@@ -791,7 +799,7 @@ static inline int _esh_session_init(size_t idx, ns_map_data_t *m, size_t jobuid,
         }
     }
 
-#ifdef PTHREAD_LOCK
+#ifdef ESH_PTHREAD_LOCK
     if ( PMIX_SUCCESS != (rc = _rwlock_init(m->tbl_idx, s->lockfile))) {
         PMIX_ERROR_LOG(rc);
         return rc;
@@ -823,7 +831,7 @@ static inline void _esh_session_release(session_t *s)
         }
         free(s->nspace_path);
     }
-#ifdef PTHREAD_LOCK
+#ifdef ESH_PTHREAD_LOCK
     _rwlock_release(s);
 #endif
     memset ((char *) s, 0, sizeof(*s));

--- a/src/dstore/pmix_esh.c
+++ b/src/dstore/pmix_esh.c
@@ -14,7 +14,6 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
 #include <sys/file.h>
 #include <dirent.h>
 #include <errno.h>
@@ -34,6 +33,14 @@
 
 #include "pmix_dstore.h"
 #include "pmix_esh.h"
+
+#ifdef FCNTL_LOCK
+#include <fcntl.h>
+#endif
+
+#ifdef PTHREAD_LOCK
+#include <pthread.h>
+#endif
 
 static int _esh_init(pmix_info_t info[], size_t ninfo);
 static int _esh_finalize(void);
@@ -119,6 +126,43 @@ __extension__ ({                                            \
             buffer, size);                                  \
 })
 
+#ifdef PTHREAD_LOCK
+#define _ESH_LOCK(rwlock, operation)                        \
+__extension__ ({                                            \
+    pmix_status_t ret = PMIX_SUCCESS;                       \
+    int rc;                                                 \
+    switch (operation) {                                    \
+        case F_WRLCK:                                       \
+            rc = pthread_rwlock_wrlock(rwlock);             \
+            break;                                          \
+        case F_RDLCK:                                       \
+            rc = pthread_rwlock_rdlock(rwlock);             \
+            break;                                          \
+        case F_UNLCK:                                       \
+            rc = pthread_rwlock_unlock(rwlock);             \
+            break;                                          \
+        default:                                            \
+            rc = PMIX_ERR_BAD_PARAM;                        \
+    }                                                       \
+    if (0 != rc) {                                          \
+        switch (errno) {                                    \
+            case EINVAL:                                    \
+                ret = PMIX_ERR_INIT;                        \
+                break;                                      \
+            case EPERM:                                     \
+                ret = PMIX_ERR_NO_PERMISSIONS;              \
+                break;                                      \
+        }                                                   \
+    }                                                       \
+    if (ret) {                                              \
+        pmix_output(0, "%s %d:%s lock failed: %s",          \
+            __FILE__, __LINE__, __func__, strerror(errno)); \
+    }                                                       \
+    ret;                                                    \
+})
+#endif
+
+#ifdef FCNTL_LOCK
 #define _ESH_LOCK(lockfd, operation)                        \
 __extension__ ({                                            \
     pmix_status_t ret = PMIX_SUCCESS;                       \
@@ -156,10 +200,11 @@ __extension__ ({                                            \
     }                                                       \
     ret;                                                    \
 })
+#endif
 
-#define _ESH_WRLOCK(lockfd) _ESH_LOCK(lockfd, F_WRLCK)
-#define _ESH_RDLOCK(lockfd) _ESH_LOCK(lockfd, F_RDLCK)
-#define _ESH_UNLOCK(lockfd) _ESH_LOCK(lockfd, F_UNLCK)
+#define _ESH_WRLOCK(lock) _ESH_LOCK(lock, F_WRLCK)
+#define _ESH_RDLOCK(lock) _ESH_LOCK(lock, F_RDLCK)
+#define _ESH_UNLOCK(lock) _ESH_LOCK(lock, F_UNLCK)
 
 #define ESH_INIT_SESSION_TBL_SIZE 2
 #define ESH_INIT_NS_MAP_TBL_SIZE  2
@@ -198,6 +243,7 @@ static size_t _max_ns_num;
 static size_t _meta_segment_size = 0;
 static size_t _max_meta_elems;
 static size_t _data_segment_size = 0;
+static size_t _lock_segment_size = 0;
 static uid_t _jobuid;
 static char _setjobuid = 0;
 
@@ -210,10 +256,20 @@ ns_map_data_t * (*_esh_session_map_search)(const char *nspace) = NULL;
 #define _ESH_SESSION_path(tbl_idx)         (PMIX_VALUE_ARRAY_GET_BASE(_session_array, session_t)[tbl_idx].nspace_path)
 #define _ESH_SESSION_lockfile(tbl_idx)     (PMIX_VALUE_ARRAY_GET_BASE(_session_array, session_t)[tbl_idx].lockfile)
 #define _ESH_SESSION_jobuid(tbl_idx)       (PMIX_VALUE_ARRAY_GET_BASE(_session_array, session_t)[tbl_idx].jobuid)
-#define _ESH_SESSION_lockfd(tbl_idx)       (PMIX_VALUE_ARRAY_GET_BASE(_session_array, session_t)[tbl_idx].lockfd)
 #define _ESH_SESSION_sm_seg_first(tbl_idx) (PMIX_VALUE_ARRAY_GET_BASE(_session_array, session_t)[tbl_idx].sm_seg_first)
 #define _ESH_SESSION_sm_seg_last(tbl_idx)  (PMIX_VALUE_ARRAY_GET_BASE(_session_array, session_t)[tbl_idx].sm_seg_last)
 #define _ESH_SESSION_ns_info(tbl_idx)      (PMIX_VALUE_ARRAY_GET_BASE(_session_array, session_t)[tbl_idx].ns_info)
+
+#ifdef PTHREAD_LOCK
+#define _ESH_SESSION_pthread_rwlock(tbl_idx) (PMIX_VALUE_ARRAY_GET_BASE(_session_array, session_t)[tbl_idx].rwlock)
+#define _ESH_SESSION_pthread_seg(tbl_idx)   (PMIX_VALUE_ARRAY_GET_BASE(_session_array, session_t)[tbl_idx].rwlock_seg)
+#define _ESH_SESSION_lock(tbl_idx)         _ESH_SESSION_pthread_rwlock(tbl_idx)
+#endif
+
+#ifdef FCNTL_LOCK
+#define _ESH_SESSION_lockfd(tbl_idx)       (PMIX_VALUE_ARRAY_GET_BASE(_session_array, session_t)[tbl_idx].lockfd)
+#define _ESH_SESSION_lock(tbl_idx)         _ESH_SESSION_lockfd(tbl_idx)
+#endif
 
 /* If _direct_mode is set, it means that we use linear search
  * along the array of rank meta info objects inside a meta segment
@@ -251,6 +307,85 @@ static inline void _esh_session_map_clean(ns_map_t *m) {
     memset(m, 0, sizeof(*m));
     m->data.track_idx = -1;
 }
+
+#ifdef PTHREAD_LOCK
+static inline int _rwlock_init(size_t idx, char *lockfile) {
+    pmix_status_t rc = PMIX_SUCCESS;
+    size_t size = _lock_segment_size;
+    pthread_rwlockattr_t attr;
+
+    if ((NULL != _ESH_SESSION_pthread_seg(idx)) || (NULL != _ESH_SESSION_pthread_rwlock(idx))) {
+        rc = PMIX_ERR_INIT;
+        return rc;
+    }
+    _ESH_SESSION_pthread_seg(idx) = (pmix_sm_seg_t *)malloc(sizeof(pmix_sm_seg_t));
+    if (NULL == _ESH_SESSION_pthread_seg(idx)) {
+        rc = PMIX_ERR_OUT_OF_RESOURCE;
+        return rc;
+    }
+
+    if (_is_server()) {
+        if (PMIX_SUCCESS != (rc = pmix_sm_segment_create(_ESH_SESSION_pthread_seg(idx), lockfile, size))) {
+            return rc;
+        }
+        memset(_ESH_SESSION_pthread_seg(idx)->seg_base_addr, 0, size);
+        _ESH_SESSION_pthread_rwlock(idx) = (pthread_rwlock_t *)_ESH_SESSION_pthread_seg(idx)->seg_base_addr;
+
+        if (0 != pthread_rwlockattr_init(&attr)) {
+            rc = PMIX_ERR_INIT;
+            pmix_sm_segment_detach(_ESH_SESSION_pthread_seg(idx));
+            return rc;
+        }
+        if (0 != pthread_rwlockattr_setpshared(&attr, PTHREAD_PROCESS_SHARED)) {
+            rc = PMIX_ERR_INIT;
+            pmix_sm_segment_detach(_ESH_SESSION_pthread_seg(idx));
+            pthread_rwlockattr_destroy(&attr);
+            return rc;
+        }
+        if (0 != pthread_rwlock_init(_ESH_SESSION_pthread_rwlock(idx), &attr)) {
+            rc = PMIX_ERR_INIT;
+            pmix_sm_segment_detach(_ESH_SESSION_pthread_seg(idx));
+            pthread_rwlockattr_destroy(&attr);
+            return rc;
+        }
+        if (0 != pthread_rwlockattr_destroy(&attr)) {
+            rc = PMIX_ERR_INIT;
+            return rc;
+        }
+
+    }
+    else {
+        _ESH_SESSION_pthread_seg(idx)->seg_size = size;
+        snprintf(_ESH_SESSION_pthread_seg(idx)->seg_name, PMIX_PATH_MAX, "%s", lockfile);
+        if (PMIX_SUCCESS != (rc = pmix_sm_segment_attach(_ESH_SESSION_pthread_seg(idx), PMIX_SM_RW))) {
+            return rc;
+        }
+        _ESH_SESSION_pthread_rwlock(idx) = (pthread_rwlock_t *)_ESH_SESSION_pthread_seg(idx)->seg_base_addr;
+    }
+
+    return rc;
+}
+
+static inline void _rwlock_release(session_t *s) {
+    pmix_status_t rc;
+
+    if (0 != pthread_rwlock_destroy(s->rwlock)) {
+        rc = PMIX_ERROR;
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+
+    /* detach & unlink from current desc */
+    if (s->rwlock_seg->seg_cpid == getpid()) {
+        pmix_sm_segment_unlink(s->rwlock_seg);
+    }
+    pmix_sm_segment_detach(s->rwlock_seg);
+
+    free(s->rwlock_seg);
+    s->rwlock_seg = NULL;
+    s->rwlock = NULL;
+}
+#endif
 
 static inline const char *_unique_id(void)
 {
@@ -656,6 +791,12 @@ static inline int _esh_session_init(size_t idx, ns_map_data_t *m, size_t jobuid,
         }
     }
 
+#ifdef PTHREAD_LOCK
+    if ( PMIX_SUCCESS != (rc = _rwlock_init(m->tbl_idx, s->lockfile))) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+#endif
     s->sm_seg_first = seg;
     s->sm_seg_last = s->sm_seg_first;
     return PMIX_SUCCESS;
@@ -682,6 +823,9 @@ static inline void _esh_session_release(session_t *s)
         }
         free(s->nspace_path);
     }
+#ifdef PTHREAD_LOCK
+    _rwlock_release(s);
+#endif
     memset ((char *) s, 0, sizeof(*s));
 }
 
@@ -885,7 +1029,7 @@ int _esh_store(const char *nspace, int rank, pmix_kval_t *kv)
     }
 
     /* set exclusive lock */
-    if (PMIX_SUCCESS != (rc = _ESH_WRLOCK(_ESH_SESSION_lockfd(ns_map->tbl_idx)))) {
+    if (PMIX_SUCCESS != (rc = _ESH_WRLOCK(_ESH_SESSION_lock(ns_map->tbl_idx)))) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }
@@ -950,14 +1094,14 @@ int _esh_store(const char *nspace, int rank, pmix_kval_t *kv)
     }
 
     /* unset lock */
-    if (PMIX_SUCCESS != (rc = _ESH_UNLOCK(_ESH_SESSION_lockfd(ns_map->tbl_idx)))) {
+    if (PMIX_SUCCESS != (rc = _ESH_UNLOCK(_ESH_SESSION_lock(ns_map->tbl_idx)))) {
         PMIX_ERROR_LOG(rc);
     }
     return rc;
 
 err_exit:
     /* unset lock */
-    if (PMIX_SUCCESS != (tmp_rc = _ESH_UNLOCK(_ESH_SESSION_lockfd(ns_map->tbl_idx)))) {
+    if (PMIX_SUCCESS != (tmp_rc = _ESH_UNLOCK(_ESH_SESSION_lock(ns_map->tbl_idx)))) {
         PMIX_ERROR_LOG(tmp_rc);
     }
     return rc;
@@ -1018,7 +1162,7 @@ int _esh_fetch(const char *nspace, int rank, const char *key, pmix_value_t **kvs
     }
 
     /* grab shared lock */
-    if (PMIX_SUCCESS != (lock_rc = _ESH_RDLOCK(_ESH_SESSION_lockfd(ns_map->tbl_idx)))) {
+    if (PMIX_SUCCESS != (lock_rc = _ESH_RDLOCK(_ESH_SESSION_lock(ns_map->tbl_idx)))) {
         /* Something wrong with the lock. The error is fatal */
         rc = PMIX_ERROR;
         PMIX_ERROR_LOG(lock_rc);
@@ -1177,7 +1321,7 @@ int _esh_fetch(const char *nspace, int rank, const char *key, pmix_value_t **kvs
 
 done:
     /* unset lock */
-    if (PMIX_SUCCESS != (lock_rc = _ESH_UNLOCK(_ESH_SESSION_lockfd(ns_map->tbl_idx)))) {
+    if (PMIX_SUCCESS != (lock_rc = _ESH_UNLOCK(_ESH_SESSION_lock(ns_map->tbl_idx)))) {
         PMIX_ERROR_LOG(lock_rc);
     }
 
@@ -1377,6 +1521,7 @@ static void _set_constants_from_env()
         }
     }
 
+    _lock_segment_size = page_size;
     _max_ns_num = (_initial_segment_size - sizeof(size_t) * 2) / sizeof(ns_seg_info_t);
     _max_meta_elems = (_meta_segment_size - sizeof(size_t)) / sizeof(rank_meta_info);
 

--- a/src/dstore/pmix_esh.h
+++ b/src/dstore/pmix_esh.h
@@ -24,6 +24,23 @@ BEGIN_C_DECLS
 
 #define PMIX_DSTORE_ESH_BASE_PATH "PMIX_DSTORE_ESH_BASE_PATH"
 
+#define PTHREAD_LOCK_ENABLE 1
+#define FCNTL_LOCK_ENABLE   0
+
+#if defined(PTHREAD_LOCK_ENABLE) || defined(FCNTL_LOCK_ENABLE)
+#if (PTHREAD_LOCK_ENABLE == 1)
+#undef FCNTL_LOCK_ENABLE
+#define PTHREAD_LOCK
+#else
+#undef PTHREAD_LOCK_ENABLE
+#define FCNTL_LOCK
+#endif
+#elif !(defined(PTHREAD_LOCK_ENABLE) || defined(FCNTL_LOCK_ENABLE))
+#error not enabled any one type of locking
+#else
+#define PTHREAD_LOCK
+#endif
+
 /* this structs are used to store information about
  * shared segments addresses locally at each process,
  * so they are common for different types of segments
@@ -47,12 +64,17 @@ struct seg_desc_t {
 typedef struct ns_map_data_s ns_map_data_t;
 typedef struct session_s session_t;
 typedef struct ns_map_s ns_map_t;
+typedef struct rwlock_map_s rwlock_map_t;
 
 struct session_s {
     int in_use;
     uid_t jobuid;
     char *nspace_path;
     char *lockfile;
+#ifdef PTHREAD_LOCK
+    pmix_sm_seg_t *rwlock_seg;
+    pthread_rwlock_t *rwlock;
+#endif
     int lockfd;
     seg_desc_t *sm_seg_first;
     seg_desc_t *sm_seg_last;

--- a/src/dstore/pmix_esh.h
+++ b/src/dstore/pmix_esh.h
@@ -24,21 +24,12 @@ BEGIN_C_DECLS
 
 #define PMIX_DSTORE_ESH_BASE_PATH "PMIX_DSTORE_ESH_BASE_PATH"
 
-#define PTHREAD_LOCK_ENABLE 1
-#define FCNTL_LOCK_ENABLE   0
-
-#if defined(PTHREAD_LOCK_ENABLE) || defined(FCNTL_LOCK_ENABLE)
-#if (PTHREAD_LOCK_ENABLE == 1)
-#undef FCNTL_LOCK_ENABLE
-#define PTHREAD_LOCK
+#ifdef HAVE_PTHREAD_SHARED
+#define ESH_PTHREAD_LOCK
+#elif defined HAVE_FCNTL_FLOCK
+#define ESH_FCNTL_LOCK
 #else
-#undef PTHREAD_LOCK_ENABLE
-#define FCNTL_LOCK
-#endif
-#elif !(defined(PTHREAD_LOCK_ENABLE) || defined(FCNTL_LOCK_ENABLE))
-#error not enabled any one type of locking
-#else
-#define PTHREAD_LOCK
+#error No locking mechanism was found
 #endif
 
 /* this structs are used to store information about
@@ -64,14 +55,13 @@ struct seg_desc_t {
 typedef struct ns_map_data_s ns_map_data_t;
 typedef struct session_s session_t;
 typedef struct ns_map_s ns_map_t;
-typedef struct rwlock_map_s rwlock_map_t;
 
 struct session_s {
     int in_use;
     uid_t jobuid;
     char *nspace_path;
     char *lockfile;
-#ifdef PTHREAD_LOCK
+#ifdef ESH_PTHREAD_LOCK
     pmix_sm_seg_t *rwlock_seg;
     pthread_rwlock_t *rwlock;
 #endif


### PR DESCRIPTION
Corresponds to PR #273 

Added alternative locking by `pthread` with use shared memory region
for the lock. The code path of old locking by `flock` has been saved
for evaluate performance against locking by `pthread` and other purposes.

To change the locking type needs to enable the code paths by macro:
```C
#define PTHREAD_LOCK_ENABLE  1
#define FCNTL_LOCK_ENABLE    1
```
In priority uses the locking by `pthread`

Thanks to @artpol84 for this proof of concept.
- The  results of locking by `pthread` here: https://github.com/pmix/master/pull/260#issuecomment-273945190
- Code base of concept: https://github.com/artpol84/poc/tree/master/benchmarks/shmem_locking

Signed-off-by: Boris Karasev <karasev.b@gmail.com>
(cherry picked from commit 289e30bf06ce05b1e1ee1732c7be9019d7a6cb24)