### PR TITLE
dstore: Fix illegal memory free

### DIFF
--- a/src/dstore/pmix_esh.c
+++ b/src/dstore/pmix_esh.c
@@ -2454,7 +2454,7 @@ static int _store_data_for_rank(ns_track_elem_t *ns_info, pmix_rank_t rank, pmix
          * */
         rc = put_empty_ext_slot(ns_info->data_seg);
         if (PMIX_SUCCESS != rc) {
-            if (NULL != rinfo) {
+            if ((0 == data_exist) && NULL != rinfo) {
                 free(rinfo);
             }
             PMIX_ERROR_LOG(rc);


### PR DESCRIPTION
rinfo may point to the shared memory region or be allocated using
malloc. Release it only if it was malloc'ed.
This needs refactoring to make rinfo always point to the shared
memory ares. This will be done after v1.2.1 release.

Signed-off-by: Artem Polyakov <artpol84@gmail.com>