### PR TITLE
Fix configure logic

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016 Intel, Inc. All rights reserved
+# Copyright (c) 2015-2017 Intel, Inc.  All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -10,7 +10,7 @@
 
 # Only install the headers if we're in standalone mode
 
-if ! PMIX_EMBEDDED_MODE
+if WANT_PRIMARY_HEADERS
 include_HEADERS = \
         pmix.h \
         pmix_common.h \
@@ -23,4 +23,4 @@ nodist_include_HEADERS = \
     pmix_version.h \
     pmix_rename.h
 
-endif ! PMIX_EMBEDDED_MODE
+endif


### PR DESCRIPTION
Fix configure logic to install the primary API headers when we are not in embedded mode, or when the user has configured us --with-devel-headers. Update the tests/examples configure option so it doesn't build those by default unless the primary API headers have been installed, and errors out if someone explicitly asks for the tests and/or examples but the primary headers are not being installed as the tests and examples will fail without those.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>