### PR TITLE
Fix a race condition resulting in segfault during PMIx finalize by stopping the PMIx progress thread prior to tearing down any infrastructure

### DIFF
--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -66,11 +66,6 @@ void pmix_rte_finalize(void)
             return;
         }
         return;
-    }
-
-    if (!pmix_globals.external_evbase) {
-        /* stop the progress thread */
-        (void)pmix_progress_thread_stop(NULL);
     }
 
     /* cleanup communications */

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -268,6 +268,11 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix:server finalize called");
 
+    if (!pmix_globals.external_evbase) {
+        /* stop the progress thread */
+        (void)pmix_progress_thread_stop(NULL);
+    }
+
     pmix_ptl_base_stop_listening();
 
     cleanup_server_state();

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1636,7 +1636,9 @@ static void lmcon(pmix_dmdx_local_t *p)
 }
 static void lmdes(pmix_dmdx_local_t *p)
 {
-    PMIX_INFO_FREE(p->info, p->ninfo);
+    if (NULL != p->info) {
+        PMIX_INFO_FREE(p->info, p->ninfo);
+    }
     PMIX_LIST_DESTRUCT(&p->loc_reqs);
 }
 PMIX_CLASS_INSTANCE(pmix_dmdx_local_t,

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
@@ -516,6 +516,11 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     PMIX_WAIT_FOR_COMPLETION(active);
     pmix_output_verbose(2, pmix_globals.debug_output,
                          "pmix:tool finalize sync received");
+
+    if (!pmix_globals.external_evbase) {
+        /* stop the progress thread */
+        (void)pmix_progress_thread_stop(NULL);
+    }
 
     /* shutdown services */
     pmix_rte_finalize();


### PR DESCRIPTION


Signed-off-by: Ralph Castain <rhc@open-mpi.org>