### PR TITLE
Remove stale file reference in check_compiler_version that caused the…

### DIFF
--- a/config/pmix_check_compiler_version.m4
+++ b/config/pmix_check_compiler_version.m4
@@ -1,7 +1,7 @@
 dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
-dnl Copyright (c) 2013      Intel, Inc. All rights reserved
+dnl Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
 dnl
 dnl $COPYRIGHT$
 dnl
@@ -35,7 +35,6 @@ AC_DEFUN([PMIX_CHECK_COMPILER], [
             AC_TRY_RUN([
 #include <stdio.h>
 #include <stdlib.h>
-#include "pmix_portable_platform.h"
 
 int main (int argc, char * argv[])
 {
@@ -68,7 +67,6 @@ AC_DEFUN([PMIX_CHECK_COMPILER_STRINGIFY], [
             AC_TRY_RUN([
 #include <stdio.h>
 #include <stdlib.h>
-#include "pmix_portable_platform.h"
 
 int main (int argc, char * argv[])
 {

--- a/config/pmix_check_psm2.m4
+++ b/config/pmix_check_psm2.m4
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2006      QLogic Corp. All rights reserved.
 # Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2016      Intel Corporation. All rights reserved.
+# Copyright (c) 2016-2017 Intel, Inc.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
@@ -53,7 +53,7 @@ AC_DEFUN([PMIX_CHECK_PSM2],[
                PMIX_CHECK_PACKAGE([pmix_check_psm2],
 				  [psm2.h],
 				  [psm2],
-				  [psm_mq_irecv],
+				  [psm2_mq_irecv2],
 				  [],
 				  [$pmix_check_psm2_dir],
 				  [$pmix_check_psm2_libdir],


### PR DESCRIPTION
… tests to always fail. Update the psm2 check to look for the correct renamed function in the updated libraries.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>