### PR TITLE
Silence Coverity warning - the cb pointer cannot be NULL or else things would have failed from the very beginning.

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -745,7 +745,7 @@ request:
 respond:
 
     /* if a callback was provided, execute it */
-    if (NULL != cb && NULL != cb->value_cbfunc) {
+    if (NULL != cb->value_cbfunc) {
         if (NULL != val)  {
             /* if this is a compressed string, then uncompress it */
             if (PMIX_COMPRESSED_STRING == val->type) {


### PR DESCRIPTION


Signed-off-by: Ralph Castain <rhc@open-mpi.org>