### PR TITLE
Fix a number of abstraction breaks relating to the assign, add, active, and del of events.

### DIFF
--- a/src/class/pmix_hotel.c
+++ b/src/class/pmix_hotel.c
@@ -1,7 +1,8 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2012-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved
- * Copyright (c) 2015-2016 Intel, Inc. All rights reserved
+ * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -83,10 +84,10 @@ int pmix_hotel_init(pmix_hotel_t *h, int num_rooms,
 
         /* Create this room's event (but don't add it) */
         if (NULL != h->evbase) {
-            event_assign(&(h->rooms[i].eviction_timer_event),
-                         h->evbase,
-                         -1, 0, local_eviction_callback,
-                         &(h->eviction_args[i]));
+            pmix_event_assign(&(h->rooms[i].eviction_timer_event),
+                              h->evbase,
+                              -1, 0, local_eviction_callback,
+                              &(h->eviction_args[i]));
         }
     }
 
@@ -114,7 +115,7 @@ static void destructor(pmix_hotel_t *h)
     if (NULL != h->evbase) {
         for (i = 0; i < h->num_rooms; ++i) {
             if (NULL != h->rooms[i].occupant) {
-                event_del(&(h->rooms[i].eviction_timer_event));
+                pmix_event_del(&(h->rooms[i].eviction_timer_event));
             }
         }
     }

--- a/src/class/pmix_hotel.h
+++ b/src/class/pmix_hotel.h
@@ -1,7 +1,8 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2012-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved
- * Copyright (c) 2015-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -201,8 +202,8 @@ static inline int pmix_hotel_checkin(pmix_hotel_t *hotel,
 
     /* Assign the event and make it pending */
     if (NULL != hotel->evbase) {
-        event_add(&(room->eviction_timer_event),
-                  &(hotel->eviction_timeout));
+        pmix_event_add(&(room->eviction_timer_event),
+                       &(hotel->eviction_timeout));
     }
 
     return PMIX_SUCCESS;
@@ -226,8 +227,8 @@ static inline void pmix_hotel_checkin_with_res(pmix_hotel_t *hotel,
 
     /* Assign the event and make it pending */
     if (NULL != hotel->evbase) {
-        event_add(&(room->eviction_timer_event),
-                  &(hotel->eviction_timeout));
+        pmix_event_add(&(room->eviction_timer_event),
+                       &(hotel->eviction_timeout));
     }
 }
 
@@ -257,7 +258,7 @@ static inline void pmix_hotel_checkout(pmix_hotel_t *hotel, int room_num)
            pmix_hotel.c:local_eviction_callback(). */
         room->occupant = NULL;
         if (NULL != hotel->evbase) {
-            event_del(&(room->eviction_timer_event));
+            pmix_event_del(&(room->eviction_timer_event));
         }
         hotel->last_unoccupied_room++;
         assert(hotel->last_unoccupied_room < hotel->num_rooms);

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Artem Y. Polyakov <artpol84@gmail.com>.
@@ -88,10 +88,10 @@ static void pdes(pmix_peer_t *p)
         CLOSE_THE_SOCKET(p->sd);
     }
     if (p->send_ev_active) {
-        event_del(&p->send_event);
+        pmix_event_del(&p->send_event);
     }
     if (p->recv_ev_active) {
-        event_del(&p->recv_event);
+        pmix_event_del(&p->recv_event);
     }
 
     if (NULL != p->info) {

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
@@ -328,12 +329,12 @@ typedef struct {
 } pmix_info_caddy_t;
 PMIX_CLASS_DECLARATION(pmix_info_caddy_t);
 
-#define PMIX_THREADSHIFT(r, c)                       \
- do {                                                 \
-    (r)->active = true;                               \
-    event_assign(&((r)->ev), pmix_globals.evbase,     \
-                 -1, EV_WRITE, (c), (r));             \
-    event_active(&((r)->ev), EV_WRITE, 1);            \
+#define PMIX_THREADSHIFT(r, c)                              \
+ do {                                                       \
+    (r)->active = true;                                     \
+    pmix_event_assign(&((r)->ev), pmix_globals.evbase,      \
+                      -1, EV_WRITE, (c), (r));              \
+    pmix_event_active(&((r)->ev), EV_WRITE, 1);             \
 } while (0)
 
 

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -242,7 +242,7 @@ typedef struct event pmix_event_t;
 /* Basic event APIs */
 #define pmix_event_enable_debug_mode() event_enable_debug_mode()
 
-#define pmix_event_set(b, x, fd, fg, cb, arg) event_assign((x), (b), (fd), (fg), (event_callback_fn) (cb), (arg))
+#define pmix_event_assign(x, b, fd, fg, cb, arg) event_assign((x), (b), (fd), (fg), (event_callback_fn) (cb), (arg))
 
 #define pmix_event_add(ev, tv) event_add((ev), (tv))
 
@@ -253,5 +253,7 @@ typedef struct event pmix_event_t;
 #define pmix_event_new(b, fd, fg, cb, arg) event_new((b), (fd), (fg), (event_callback_fn) (cb), (arg))
 
 #define pmix_event_loop(b, fg) event_base_loop((b), (fg))
+
+#define pmix_event_active(x, y, z) event_active((x), (y), (z))
 
 #endif /* PMIX_TYPES_H */

--- a/src/mca/ptl/base/ptl_base_listener.c
+++ b/src/mca/ptl/base/ptl_base_listener.c
@@ -252,8 +252,8 @@ static void* listen_thread(void *obj)
                 pending_connection = PMIX_NEW(pmix_pending_connection_t);
                 pending_connection->protocol = lt->protocol;
                 pending_connection->ptl = lt->ptl;
-                event_assign(&pending_connection->ev, pmix_globals.evbase, -1,
-                             EV_WRITE, lt->cbfunc, pending_connection);
+                pmix_event_assign(&pending_connection->ev, pmix_globals.evbase, -1,
+                                  EV_WRITE, lt->cbfunc, pending_connection);
                 pending_connection->sd = accept(lt->socket,
                                                 (struct sockaddr*)&(pending_connection->addr),
                                                 &addrlen);
@@ -285,7 +285,7 @@ static void* listen_thread(void *obj)
                                     "listen_thread: new connection: (%d, %d)",
                                     pending_connection->sd, pmix_socket_errno);
                 /* activate the event */
-                event_active(&pending_connection->ev, EV_WRITE, 1);
+                pmix_event_active(&pending_connection->ev, EV_WRITE, 1);
                 accepted_connections++;
             }
         } while (accepted_connections > 0);

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -65,11 +65,11 @@ static void lost_connection(pmix_peer_t *peer, pmix_status_t err)
 
     /* stop all events */
     if (peer->recv_ev_active) {
-        event_del(&peer->recv_event);
+        pmix_event_del(&peer->recv_event);
         peer->recv_ev_active = false;
     }
     if (peer->send_ev_active) {
-        event_del(&peer->send_event);
+        pmix_event_del(&peer->send_event);
         peer->send_ev_active = false;
     }
     if (NULL != peer->recv_msg) {
@@ -304,7 +304,7 @@ void pmix_ptl_base_send_handler(int sd, short flags, void *cbdata)
             return;
         } else {
             // report the error
-            event_del(&peer->send_event);
+            pmix_event_del(&peer->send_event);
             peer->send_ev_active = false;
             PMIX_RELEASE(msg);
             peer->send_msg = NULL;
@@ -324,7 +324,7 @@ void pmix_ptl_base_send_handler(int sd, short flags, void *cbdata)
 
     /* if nothing else to do unregister for send event notifications */
     if (NULL == peer->send_msg && peer->send_ev_active) {
-        event_del(&peer->send_event);
+        pmix_event_del(&peer->send_event);
         peer->send_ev_active = false;
     }
 }
@@ -452,11 +452,11 @@ void pmix_ptl_base_recv_handler(int sd, short flags, void *cbdata)
  err_close:
     /* stop all events */
     if (peer->recv_ev_active) {
-        event_del(&peer->recv_event);
+        pmix_event_del(&peer->recv_event);
         peer->recv_ev_active = false;
     }
     if (peer->send_ev_active) {
-        event_del(&peer->send_event);
+        pmix_event_del(&peer->send_event);
         peer->send_ev_active = false;
     }
     if (NULL != peer->recv_msg) {
@@ -502,7 +502,7 @@ void pmix_ptl_base_send(int sd, short args, void *cbdata)
     }
     /* ensure the send event is active */
     if (!(queue->peer)->send_ev_active) {
-        event_add(&(queue->peer)->send_event, 0);
+        pmix_event_add(&(queue->peer)->send_event, 0);
         (queue->peer)->send_ev_active = true;
     }
     PMIX_RELEASE(queue);
@@ -563,7 +563,7 @@ void pmix_ptl_base_send_recv(int fd, short args, void *cbdata)
     }
     /* ensure the send event is active */
     if (!ms->peer->send_ev_active) {
-        event_add(&ms->peer->send_event, 0);
+        pmix_event_add(&ms->peer->send_event, 0);
         ms->peer->send_ev_active = true;
     }
     /* cleanup */

--- a/src/mca/ptl/ptl_types.h
+++ b/src/mca/ptl/ptl_types.h
@@ -193,9 +193,9 @@ PMIX_CLASS_DECLARATION(pmix_listener_t);
         pmix_output_verbose(5, pmix_globals.debug_output,               \
                             "[%s:%d] post msg",                         \
                             __FILE__, __LINE__);                        \
-        event_assign(&((ms)->ev), pmix_globals.evbase, -1,              \
-                     EV_WRITE, pmix_ptl_base_process_msg, (ms));        \
-        event_active(&((ms)->ev), EV_WRITE, 1);                         \
+        pmix_event_assign(&((ms)->ev), pmix_globals.evbase, -1,         \
+                          EV_WRITE, pmix_ptl_base_process_msg, (ms));   \
+        pmix_event_active(&((ms)->ev), EV_WRITE, 1);                    \
     } while (0)
 
 #define PMIX_SND_CADDY(c, h, s)                                         \
@@ -237,7 +237,7 @@ PMIX_CLASS_DECLARATION(pmix_listener_t);
         }                                                                               \
         /* ensure the send event is active */                                           \
         if (!(p)->send_ev_active && 0 <= (p)->sd) {                                     \
-            event_add(&(p)->send_event, 0);                                             \
+            pmix_event_add(&(p)->send_event, 0);                                        \
             (p)->send_ev_active = true;                                                 \
         }                                                                               \
     } while (0)

--- a/src/mca/ptl/tcp/ptl_tcp.c
+++ b/src/mca/ptl/tcp/ptl_tcp.c
@@ -310,20 +310,20 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
     pmix_ptl_base_set_nonblocking(sd);
 
     /* setup recv event */
-    event_assign(&pmix_client_globals.myserver.recv_event,
-                 pmix_globals.evbase,
-                 pmix_client_globals.myserver.sd,
-                 EV_READ | EV_PERSIST,
-                 pmix_ptl_base_recv_handler, &pmix_client_globals.myserver);
-    event_add(&pmix_client_globals.myserver.recv_event, 0);
+    pmix_event_assign(&pmix_client_globals.myserver.recv_event,
+                      pmix_globals.evbase,
+                      pmix_client_globals.myserver.sd,
+                      EV_READ | EV_PERSIST,
+                      pmix_ptl_base_recv_handler, &pmix_client_globals.myserver);
+    pmix_event_add(&pmix_client_globals.myserver.recv_event, 0);
     pmix_client_globals.myserver.recv_ev_active = true;
 
     /* setup send event */
-    event_assign(&pmix_client_globals.myserver.send_event,
-                 pmix_globals.evbase,
-                 pmix_client_globals.myserver.sd,
-                 EV_WRITE|EV_PERSIST,
-                 pmix_ptl_base_send_handler, &pmix_client_globals.myserver);
+    pmix_event_assign(&pmix_client_globals.myserver.send_event,
+                      pmix_globals.evbase,
+                      pmix_client_globals.myserver.sd,
+                      EV_WRITE|EV_PERSIST,
+                      pmix_ptl_base_send_handler, &pmix_client_globals.myserver);
     pmix_client_globals.myserver.send_ev_active = false;
 
     return PMIX_SUCCESS;
@@ -345,9 +345,9 @@ static pmix_status_t send_recv(struct pmix_peer_t *peer,
     ms->bfr = bfr;
     ms->cbfunc = cbfunc;
     ms->cbdata = cbdata;
-    event_assign(&ms->ev, pmix_globals.evbase, -1,
-                 EV_WRITE, pmix_ptl_base_send_recv, ms);
-    event_active(&ms->ev, EV_WRITE, 1);
+    pmix_event_assign(&ms->ev, pmix_globals.evbase, -1,
+                      EV_WRITE, pmix_ptl_base_send_recv, ms);
+    pmix_event_active(&ms->ev, EV_WRITE, 1);
     return PMIX_SUCCESS;
 }
 
@@ -366,9 +366,9 @@ static pmix_status_t send_oneway(struct pmix_peer_t *peer,
     q->peer = peer;
     q->buf = bfr;
     q->tag = tag;
-    event_assign(&q->ev, pmix_globals.evbase, -1,
-                 EV_WRITE, pmix_ptl_base_send, q);
-    event_active(&q->ev, EV_WRITE, 1);
+    pmix_event_assign(&q->ev, pmix_globals.evbase, -1,
+                      EV_WRITE, pmix_ptl_base_send, q);
+    pmix_event_active(&q->ev, EV_WRITE, 1);
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -1010,12 +1010,12 @@ static void connection_handler(int sd, short args, void *cbdata)
     pmix_ptl_base_set_nonblocking(pnd->sd);
 
     /* start the events for this client */
-    event_assign(&peer->recv_event, pmix_globals.evbase, pnd->sd,
-                 EV_READ|EV_PERSIST, pmix_ptl_base_recv_handler, peer);
-    event_add(&peer->recv_event, NULL);
+    pmix_event_assign(&peer->recv_event, pmix_globals.evbase, pnd->sd,
+                      EV_READ|EV_PERSIST, pmix_ptl_base_recv_handler, peer);
+    pmix_event_add(&peer->recv_event, NULL);
     peer->recv_ev_active = true;
-    event_assign(&peer->send_event, pmix_globals.evbase, pnd->sd,
-                 EV_WRITE|EV_PERSIST, pmix_ptl_base_send_handler, peer);
+    pmix_event_assign(&peer->send_event, pmix_globals.evbase, pnd->sd,
+                      EV_WRITE|EV_PERSIST, pmix_ptl_base_send_handler, peer);
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "pmix:server client %s:%u has connected on socket %d",
                         peer->info->nptr->nspace, peer->info->rank, peer->sd);
@@ -1151,12 +1151,12 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     }
 
     /* start the events for this tool */
-    event_assign(&peer->recv_event, pmix_globals.evbase, pnd->sd,
-                 EV_READ|EV_PERSIST, pmix_ptl_base_recv_handler, peer);
-    event_add(&peer->recv_event, NULL);
+    pmix_event_assign(&peer->recv_event, pmix_globals.evbase, pnd->sd,
+                      EV_READ|EV_PERSIST, pmix_ptl_base_recv_handler, peer);
+    pmix_event_add(&peer->recv_event, NULL);
     peer->recv_ev_active = true;
-    event_assign(&peer->send_event, pmix_globals.evbase, pnd->sd,
-                 EV_WRITE|EV_PERSIST, pmix_ptl_base_send_handler, peer);
+    pmix_event_assign(&peer->send_event, pmix_globals.evbase, pnd->sd,
+                      EV_WRITE|EV_PERSIST, pmix_ptl_base_send_handler, peer);
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "pmix:server tool %s:%d has connected on socket %d",
                         peer->info->nptr->nspace, peer->info->rank, peer->sd);

--- a/src/mca/ptl/usock/ptl_usock.c
+++ b/src/mca/ptl/usock/ptl_usock.c
@@ -164,20 +164,20 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
     pmix_ptl_base_set_nonblocking(sd);
 
     /* setup recv event */
-    event_assign(&pmix_client_globals.myserver.recv_event,
-                 pmix_globals.evbase,
-                 pmix_client_globals.myserver.sd,
-                 EV_READ | EV_PERSIST,
-                 pmix_ptl_base_recv_handler, &pmix_client_globals.myserver);
-    event_add(&pmix_client_globals.myserver.recv_event, 0);
+    pmix_event_assign(&pmix_client_globals.myserver.recv_event,
+                      pmix_globals.evbase,
+                      pmix_client_globals.myserver.sd,
+                      EV_READ | EV_PERSIST,
+                      pmix_ptl_base_recv_handler, &pmix_client_globals.myserver);
+    pmix_event_add(&pmix_client_globals.myserver.recv_event, 0);
     pmix_client_globals.myserver.recv_ev_active = true;
 
     /* setup send event */
-    event_assign(&pmix_client_globals.myserver.send_event,
-                 pmix_globals.evbase,
-                 pmix_client_globals.myserver.sd,
-                 EV_WRITE|EV_PERSIST,
-                 pmix_ptl_base_send_handler, &pmix_client_globals.myserver);
+    pmix_event_assign(&pmix_client_globals.myserver.send_event,
+                      pmix_globals.evbase,
+                      pmix_client_globals.myserver.sd,
+                      EV_WRITE|EV_PERSIST,
+                      pmix_ptl_base_send_handler, &pmix_client_globals.myserver);
     pmix_client_globals.myserver.send_ev_active = false;
 
     return PMIX_SUCCESS;
@@ -199,9 +199,9 @@ static pmix_status_t send_recv(struct pmix_peer_t *peer,
     ms->bfr = bfr;
     ms->cbfunc = cbfunc;
     ms->cbdata = cbdata;
-    event_assign(&ms->ev, pmix_globals.evbase, -1,
-                 EV_WRITE, pmix_ptl_base_send_recv, ms);
-    event_active(&ms->ev, EV_WRITE, 1);
+    pmix_event_assign(&ms->ev, pmix_globals.evbase, -1,
+                      EV_WRITE, pmix_ptl_base_send_recv, ms);
+    pmix_event_active(&ms->ev, EV_WRITE, 1);
     return PMIX_SUCCESS;
 }
 
@@ -220,9 +220,9 @@ static pmix_status_t send_oneway(struct pmix_peer_t *peer,
     q->peer = peer;
     q->buf = bfr;
     q->tag = tag;
-    event_assign(&q->ev, pmix_globals.evbase, -1,
-                 EV_WRITE, pmix_ptl_base_send, q);
-    event_active(&q->ev, EV_WRITE, 1);
+    pmix_event_assign(&q->ev, pmix_globals.evbase, -1,
+                      EV_WRITE, pmix_ptl_base_send, q);
+    pmix_event_active(&q->ev, EV_WRITE, 1);
 
     return PMIX_SUCCESS;
 }

--- a/src/mca/ptl/usock/ptl_usock_component.c
+++ b/src/mca/ptl/usock/ptl_usock_component.c
@@ -346,9 +346,9 @@ static void listener_cb(int incoming_sd, void *cbdata)
                         incoming_sd);
     pending_connection = PMIX_NEW(pmix_pending_connection_t);
     pending_connection->sd = incoming_sd;
-    event_assign(&pending_connection->ev, pmix_globals.evbase, -1,
-                 EV_WRITE, connection_handler, pending_connection);
-    event_active(&pending_connection->ev, EV_WRITE, 1);
+    pmix_event_assign(&pending_connection->ev, pmix_globals.evbase, -1,
+                      EV_WRITE, connection_handler, pending_connection);
+    pmix_event_active(&pending_connection->ev, EV_WRITE, 1);
 }
 
 /* Parse init-ack message:
@@ -603,12 +603,12 @@ static void connection_handler(int sd, short args, void *cbdata)
     }
 
     /* start the events for this client */
-    event_assign(&psave->recv_event, pmix_globals.evbase, pnd->sd,
-                 EV_READ|EV_PERSIST, pmix_ptl_base_recv_handler, psave);
-    event_add(&psave->recv_event, NULL);
+    pmix_event_assign(&psave->recv_event, pmix_globals.evbase, pnd->sd,
+                      EV_READ|EV_PERSIST, pmix_ptl_base_recv_handler, psave);
+    pmix_event_add(&psave->recv_event, NULL);
     psave->recv_ev_active = true;
-    event_assign(&psave->send_event, pmix_globals.evbase, pnd->sd,
-                 EV_WRITE|EV_PERSIST, pmix_ptl_base_send_handler, psave);
+    pmix_event_assign(&psave->send_event, pmix_globals.evbase, pnd->sd,
+                      EV_WRITE|EV_PERSIST, pmix_ptl_base_send_handler, psave);
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "pmix:server client %s:%u has connected on socket %d",
                         psave->info->nptr->nspace, psave->info->rank, psave->sd);

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -228,7 +228,7 @@ pmix_event_base_t *pmix_progress_thread_init(const char *name)
 
     /* add an event to the new event base (if there are no events,
        pmix_event_loop() will return immediately) */
-    pmix_event_set(trk->ev_base, &trk->block, -1, PMIX_EV_PERSIST,
+    pmix_event_assign(&trk->block, trk->ev_base, -1, PMIX_EV_PERSIST,
                    dummy_timeout_cb, trk);
     pmix_event_add(&trk->block, &long_timeout);
 

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2244,7 +2244,7 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag,
         /* turn off the recv event - we shouldn't hear anything
          * more from this proc */
         if (peer->recv_ev_active) {
-            event_del(&peer->recv_event);
+            pmix_event_del(&peer->recv_event);
             peer->recv_ev_active = false;
         }
         /* let the network libraries cleanup */

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -705,8 +705,7 @@ static void dmdx_cbfunc(pmix_status_t status,
                         "[%s:%d] queue dmdx reply for %s:%u",
                         __FILE__, __LINE__,
                         caddy->lcd->proc.nspace, caddy->lcd->proc.rank);
-    event_assign(&caddy->ev, pmix_globals.evbase, -1, EV_WRITE,
-                 _process_dmdx_reply, caddy);
-    event_priority_set(&caddy->ev, 0);
-    event_active(&caddy->ev, EV_WRITE, 1);
+    pmix_event_assign(&caddy->ev, pmix_globals.evbase, -1, EV_WRITE,
+                      _process_dmdx_reply, caddy);
+    pmix_event_active(&caddy->ev, EV_WRITE, 1);
 }

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2015-2016 Intel, Inc. All rights reserved
+ * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
@@ -132,9 +132,9 @@ typedef struct {
 #define PMIX_EXECUTE_COLLECTIVE(c, t, f)                        \
     do {                                                        \
         PMIX_SETUP_COLLECTIVE(c, t);                            \
-        event_assign(&((c)->ev), pmix_globals.evbase, -1,       \
-                     EV_WRITE, (f), (c));                       \
-        event_active(&((c)->ev), EV_WRITE, 1);                  \
+        pmix_event_assign(&((c)->ev), pmix_globals.evbase, -1,  \
+                          EV_WRITE, (f), (c));                  \
+        pmix_event_active(&((c)->ev), EV_WRITE, 1);             \
     } while (0)
 
 

--- a/test/simple/simpclient.c
+++ b/test/simple/simpclient.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -204,23 +204,13 @@ int main(int argc, char **argv)
 
                 (void)asprintf(&tmp, "%s-%d-remote-%d", proc.nspace, n, j);
                 if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
-                    pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s failed: %s",
-                                myproc.nspace, myproc.rank, j, tmp, PMIx_Error_string(rc));
+                    /* this data should _not_ be found as we are on the same node
+                     * and the data was "put" with a PMIX_REMOTE scope */
+                    pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s returned correct", myproc.nspace, myproc.rank, j, tmp);
                     continue;
                 }
-                if (PMIX_STRING != val->type) {
-                    pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s returned wrong type: %d", myproc.nspace, myproc.rank, j, tmp, val->type);
-                    PMIX_VALUE_RELEASE(val);
-                    free(tmp);
-                    continue;
-                }
-                if (0 != strcmp(val->data.string, "1234")) {
-                    pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s returned wrong value: %s", myproc.nspace, myproc.rank, j, tmp, val->data.string);
-                    PMIX_VALUE_RELEASE(val);
-                    free(tmp);
-                    continue;
-                }
-                pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s returned correct", myproc.nspace, myproc.rank, j, tmp);
+                pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s returned remote data for a local proc",
+                            myproc.nspace, myproc.rank, j, tmp);
                 PMIX_VALUE_RELEASE(val);
                 free(tmp);
             }


### PR DESCRIPTION
Thanks to Nathan Hjelmn for pointing them out

Signed-off-by: Ralph Castain <rhc@open-mpi.org>